### PR TITLE
feat: upgrade analytics to realtime Sheets + GA4 hybrid system

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_GA_API_URL=

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_GA_API_URL=https://script.google.com/macros/s/AKfycbya_lo-437-LxSwtBlKtuIfLZWim1cfHfB_vDPjqmqlSFq2K3w1cMhYoZqzEyQB19tm/exec

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,8 @@ dist
 dist-ssr
 
 # Environment
-*.local
-.env
-.env.*
+.env.local
+.env.*.local
 
 # Logs
 *.log

--- a/apps-script/.clasp.json
+++ b/apps-script/.clasp.json
@@ -1,0 +1,16 @@
+{
+  "scriptId": "1GX3POjQxuFWbrJCN1YcMPuwDXS1543dCF9nj9hDzev_6e4RbPn0aoCIn",
+  "rootDir": "",
+  "scriptExtensions": [
+    ".js",
+    ".gs"
+  ],
+  "htmlExtensions": [
+    ".html"
+  ],
+  "jsonExtensions": [
+    ".json"
+  ],
+  "filePushOrder": [],
+  "skipSubdirectories": false
+}

--- a/apps-script/Code.js
+++ b/apps-script/Code.js
@@ -1,0 +1,318 @@
+var PROPERTY_ID = '306384783';
+var SPREADSHEET_ID = '1X-OWsZhJwQcvkDGvMKcTuz2z-OQEF8hi2ac6V0NXMmg';
+var CACHE_TTL = 300; // 5분
+
+/**
+ * GET 요청: summary + daily 합산 단일 응답
+ * CacheService 5분 캐시 적용
+ */
+function doGet() {
+  var cache = CacheService.getScriptCache();
+  var cached = cache.get('pageviews_response');
+
+  if (cached) {
+    return ContentService
+      .createTextOutput(cached)
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+
+  var sheetsData = getSheetsData();
+  var dailyData = getSheetsDailyData();
+  var ga4Daily = getGA4Daily();
+
+  // Sheets daily + GA4 daily 병합 (Sheets 우선)
+  var dailyMap = {};
+  for (var i = 0; i < ga4Daily.length; i++) {
+    dailyMap[ga4Daily[i].date] = ga4Daily[i].views;
+  }
+  for (var i = 0; i < dailyData.length; i++) {
+    var d = dailyData[i].date;
+    dailyMap[d] = (dailyMap[d] || 0) + dailyData[i].views;
+  }
+
+  var daily = [];
+  var dates = Object.keys(dailyMap).sort();
+  for (var i = 0; i < dates.length; i++) {
+    daily.push({ date: dates[i], views: dailyMap[dates[i]] });
+  }
+
+  var response = {
+    totalViews: sheetsData.totalViews,
+    pages: sheetsData.pages,
+    daily: daily,
+    meta: {
+      cachedAt: new Date().toISOString(),
+      source: 'sheets+ga4'
+    }
+  };
+
+  var json = JSON.stringify(response);
+  cache.put('pageviews_response', json, CACHE_TTL);
+
+  return ContentService
+    .createTextOutput(json)
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+/**
+ * POST 요청: 방문 기록을 Sheets에 실시간 기록
+ * sendBeacon으로 호출됨 (text/plain)
+ */
+function doPost(e) {
+  try {
+    var body = e.postData ? e.postData.contents : '';
+    var data = JSON.parse(body);
+    var path = normalizePath(data.path || '');
+
+    if (!path || !path.startsWith('/')) {
+      return jsonResponse({ success: false, error: 'invalid path' });
+    }
+
+    // 봇 필터링
+    var ua = (data.userAgent || '').toLowerCase();
+    if (isBot(ua)) {
+      return jsonResponse({ success: false, error: 'bot' });
+    }
+
+    // PageViews 시트에 카운트 증가
+    incrementPageView(path);
+
+    // DailyViews 시트에 오늘 날짜 카운트 증가
+    incrementDailyView();
+
+    // 캐시 무효화
+    CacheService.getScriptCache().remove('pageviews_response');
+
+    return jsonResponse({ success: true });
+  } catch (err) {
+    return jsonResponse({ success: false, error: err.message });
+  }
+}
+
+// ─── Sheets 데이터 조회 ───
+
+function getSheetsData() {
+  if (!SPREADSHEET_ID) {
+    return { totalViews: 0, pages: {} };
+  }
+
+  try {
+    var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+    var sheet = ss.getSheetByName('PageViews');
+    if (!sheet || sheet.getLastRow() < 2) {
+      return { totalViews: 0, pages: {} };
+    }
+
+    var data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
+    var pages = {};
+    var totalViews = 0;
+
+    for (var i = 0; i < data.length; i++) {
+      var path = String(data[i][0]);
+      var count = Number(data[i][1]) || 0;
+      if (path) {
+        pages[path] = count;
+        totalViews += count;
+      }
+    }
+
+    return { totalViews: totalViews, pages: pages };
+  } catch (err) {
+    Logger.log('getSheetsData error: ' + err.message);
+    return { totalViews: 0, pages: {} };
+  }
+}
+
+function getSheetsDailyData() {
+  if (!SPREADSHEET_ID) return [];
+
+  try {
+    var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+    var sheet = ss.getSheetByName('DailyViews');
+    if (!sheet || sheet.getLastRow() < 2) return [];
+
+    var data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
+    var daily = [];
+
+    // 최근 30일만 반환
+    var cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 30);
+    var cutoffStr = formatDate(cutoff);
+
+    for (var i = 0; i < data.length; i++) {
+      var raw = data[i][0];
+      var date = (raw instanceof Date) ? formatDate(raw) : String(raw);
+      var views = Number(data[i][1]) || 0;
+      if (date >= cutoffStr) {
+        daily.push({ date: date, views: views });
+      }
+    }
+
+    return daily;
+  } catch (err) {
+    Logger.log('getSheetsDailyData error: ' + err.message);
+    return [];
+  }
+}
+
+// ─── Sheets 기록 ───
+
+function incrementPageView(path) {
+  if (!SPREADSHEET_ID) return;
+
+  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  var sheet = ss.getSheetByName('PageViews');
+  if (!sheet) {
+    sheet = ss.insertSheet('PageViews');
+    sheet.appendRow(['path', 'count', 'lastVisited']);
+  }
+
+  var lastRow = sheet.getLastRow();
+  var found = false;
+
+  if (lastRow >= 2) {
+    var paths = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
+    for (var i = 0; i < paths.length; i++) {
+      if (String(paths[i][0]) === path) {
+        var row = i + 2;
+        var currentCount = Number(sheet.getRange(row, 2).getValue()) || 0;
+        sheet.getRange(row, 2).setValue(currentCount + 1);
+        sheet.getRange(row, 3).setValue(new Date().toISOString());
+        found = true;
+        break;
+      }
+    }
+  }
+
+  if (!found) {
+    sheet.appendRow([path, 1, new Date().toISOString()]);
+  }
+}
+
+function incrementDailyView() {
+  if (!SPREADSHEET_ID) return;
+
+  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  var sheet = ss.getSheetByName('DailyViews');
+  if (!sheet) {
+    sheet = ss.insertSheet('DailyViews');
+    sheet.appendRow(['date', 'views']);
+  }
+
+  var today = formatDate(new Date());
+  var lastRow = sheet.getLastRow();
+  var found = false;
+
+  if (lastRow >= 2) {
+    var dates = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
+    for (var i = 0; i < dates.length; i++) {
+      if (String(dates[i][0]) === today) {
+        var row = i + 2;
+        var currentCount = Number(sheet.getRange(row, 2).getValue()) || 0;
+        sheet.getRange(row, 2).setValue(currentCount + 1);
+        found = true;
+        break;
+      }
+    }
+  }
+
+  if (!found) {
+    sheet.appendRow([today, 1]);
+  }
+}
+
+// ─── GA4 데이터 (daily용, 상세 분석) ───
+
+function getGA4Daily() {
+  try {
+    var request = AnalyticsData.newRunReportRequest();
+    request.dateRanges = [AnalyticsData.newDateRange()];
+    request.dateRanges[0].startDate = '30daysAgo';
+    request.dateRanges[0].endDate = 'today';
+    request.dimensions = [AnalyticsData.newDimension()];
+    request.dimensions[0].name = 'date';
+    request.metrics = [AnalyticsData.newMetric()];
+    request.metrics[0].name = 'screenPageViews';
+    request.orderBys = [AnalyticsData.newOrderBy()];
+    request.orderBys[0].dimension = AnalyticsData.newDimensionOrderBy();
+    request.orderBys[0].dimension.dimensionName = 'date';
+
+    var response = AnalyticsData.Properties.runReport(
+      request, 'properties/' + PROPERTY_ID
+    );
+
+    var daily = [];
+    if (response.rows) {
+      for (var i = 0; i < response.rows.length; i++) {
+        var dateStr = response.rows[i].dimensionValues[0].value;
+        var views = parseInt(response.rows[i].metricValues[0].value);
+        daily.push({
+          date: dateStr.substring(0, 4) + '-' + dateStr.substring(4, 6) + '-' + dateStr.substring(6, 8),
+          views: views
+        });
+      }
+    }
+    return daily;
+  } catch (err) {
+    Logger.log('getGA4Daily error: ' + err.message);
+    return [];
+  }
+}
+
+// ─── 유틸리티 ───
+
+function normalizePath(path) {
+  if (!path) return '';
+  // trailing slash 제거 (루트 제외)
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.slice(0, -1);
+  }
+  // 연속 슬래시 제거
+  path = path.replace(/\/+/g, '/');
+  return path;
+}
+
+function isBot(ua) {
+  var bots = ['bot', 'crawl', 'spider', 'slurp', 'mediapartners', 'prerender', 'lighthouse', 'pagespeed', 'headless'];
+  for (var i = 0; i < bots.length; i++) {
+    if (ua.indexOf(bots[i]) !== -1) return true;
+  }
+  return false;
+}
+
+function formatDate(d) {
+  var yyyy = d.getFullYear();
+  var mm = String(d.getMonth() + 1).padStart(2, '0');
+  var dd = String(d.getDate()).padStart(2, '0');
+  return yyyy + '-' + mm + '-' + dd;
+}
+
+function jsonResponse(obj) {
+  return ContentService
+    .createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+// ─── 권한 승인용 (try-catch 없이 직접 호출) ───
+
+function authorizeSheets() {
+  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  Logger.log('Sheets authorized: ' + ss.getName());
+}
+
+// ─── 테스트 ───
+
+function testDoGet() {
+  var result = doGet();
+  Logger.log(result.getContent());
+}
+
+function testDoPost() {
+  var e = {
+    postData: {
+      contents: JSON.stringify({ path: '/posts/test-post', userAgent: 'Mozilla/5.0' })
+    }
+  };
+  var result = doPost(e);
+  Logger.log(result.getContent());
+}

--- a/apps-script/appsscript.json
+++ b/apps-script/appsscript.json
@@ -1,0 +1,23 @@
+{
+  "timeZone": "Asia/Seoul",
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "AnalyticsData",
+        "version": "v1beta",
+        "serviceId": "analyticsdata"
+      }
+    ]
+  },
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/analytics.readonly",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.external_request"
+  ],
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  }
+}

--- a/src/hooks/usePageViews.ts
+++ b/src/hooks/usePageViews.ts
@@ -1,7 +1,6 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
-const GA_API_URL =
-  "https://script.google.com/macros/s/AKfycbxx7z1-AvZnCWurLcNBSWiWEDqMXwUoZeC7PsuiHQGloISAb0ZjQrUq0MWbC8pUiSMF/exec"
+const GA_API_URL = import.meta.env.VITE_GA_API_URL as string | undefined
 
 export interface DailyData {
   date: string
@@ -15,7 +14,7 @@ interface PageViewsData {
   lastUpdated: string | null
 }
 
-const CACHE_TTL = 60 * 60 * 1000 // 1시간
+const CACHE_TTL = 15 * 60 * 1000 // 15분
 
 let cached: PageViewsData | null = null
 let fetching: Promise<PageViewsData | null> | null = null
@@ -27,14 +26,18 @@ function isCacheValid(): boolean {
   return Date.now() - Number(ts) < CACHE_TTL
 }
 
-function fetchPageViews(): Promise<PageViewsData | null> {
-  if (cached && isCacheValid()) return Promise.resolve(cached)
-  if (fetching) return fetching
+function fetchPageViews(ignoreCache = false): Promise<PageViewsData | null> {
+  if (!GA_API_URL) return Promise.resolve(null)
 
-  const stored = sessionStorage.getItem("page-views")
-  if (stored && isCacheValid()) {
-    cached = JSON.parse(stored)
-    return Promise.resolve(cached)
+  if (!ignoreCache && cached && isCacheValid()) return Promise.resolve(cached)
+  if (!ignoreCache && fetching) return fetching
+
+  if (!ignoreCache) {
+    const stored = sessionStorage.getItem("page-views")
+    if (stored && isCacheValid()) {
+      cached = JSON.parse(stored)
+      return Promise.resolve(cached)
+    }
   }
 
   cached = null
@@ -84,6 +87,20 @@ export function usePageViews() {
     })
   }, [])
 
+  const refresh = useCallback(() => {
+    setIsLoading(true)
+    setIsError(false)
+    fetchPageViews(true).then((d) => {
+      if (d) {
+        setData(d)
+        setIsError(false)
+      } else {
+        setIsError(fetchError)
+      }
+      setIsLoading(false)
+    })
+  }, [])
+
   return {
     totalViews: data?.totalViews ?? null,
     allPageViews: data?.pages ?? null,
@@ -91,9 +108,11 @@ export function usePageViews() {
     isLoading,
     isError,
     lastUpdated: data?.lastUpdated ?? null,
+    refresh,
     getPostViews(slug: string): number | null {
       if (!data) return null
-      return data.pages[`/posts/${slug}`] ?? data.pages[`/posts/${slug}/`] ?? null
+      const normalized = `/posts/${slug}`
+      return data.pages[normalized] ?? null
     },
   }
 }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -85,6 +85,7 @@ export interface Translations {
     lastUpdated: string
     loadError: string
     showingCachedData: string
+    refresh: string
   }
   about: {
     description: string
@@ -214,6 +215,7 @@ export const ko: Translations = {
     lastUpdated: "마지막 업데이트",
     loadError: "조회수 데이터를 불러올 수 없습니다",
     showingCachedData: "캐시된 데이터를 표시합니다",
+    refresh: "새로고침",
   },
   about: {
     description: "복잡한 비즈니스 요구사항을 빠르게 제품으로 만들어내는 백엔드 엔지니어입니다.",
@@ -343,6 +345,7 @@ export const en: Translations = {
     lastUpdated: "Last updated",
     loadError: "Could not load view data",
     showingCachedData: "Showing cached data",
+    refresh: "Refresh",
   },
   about: {
     description: "Backend engineer who rapidly turns complex business requirements into products.",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,6 +8,31 @@ function trackEvent(eventName: string, params?: Record<string, string | number>)
   window.gtag?.("event", eventName, params)
 }
 
+const GA_API_URL = import.meta.env.VITE_GA_API_URL as string | undefined
+
+/**
+ * 방문 기록을 Apps Script → Sheets에 실시간 기록
+ * sendBeacon 사용으로 페이지 이탈 시에도 안정적
+ */
+export function trackPageVisit(path: string) {
+  // dev 모드에서는 비활성화
+  if (import.meta.env.DEV) return
+  if (!GA_API_URL) return
+
+  // 세션 내 중복 방지
+  const key = `visited:${path}`
+  if (sessionStorage.getItem(key)) return
+  sessionStorage.setItem(key, "1")
+
+  const body = JSON.stringify({
+    path,
+    userAgent: navigator.userAgent,
+  })
+
+  // sendBeacon은 text/plain으로 전송 (CORS preflight 방지)
+  navigator.sendBeacon(GA_API_URL, body)
+}
+
 export const analytics = {
   viewPost(title: string, slug: string) {
     trackEvent("view_post", { post_title: title, post_slug: slug })

--- a/src/pages/AnalyticsPage.tsx
+++ b/src/pages/AnalyticsPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import { Link } from "react-router-dom"
-import { AlertCircle, Eye, FileText, Library, PenLine, Tags } from "lucide-react"
+import { AlertCircle, Eye, FileText, Library, PenLine, RefreshCw, Tags } from "lucide-react"
 import { Bar, BarChart, CartesianGrid, Label, Pie, PieChart, XAxis, YAxis } from "recharts"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
@@ -39,7 +39,7 @@ export function AnalyticsPage() {
   const t = useT()
   useMetaTags({ title: "Analytics", description: t.analytics.description, url: "/analytics" })
 
-  const { totalViews, allPageViews, isError, lastUpdated } = usePageViews()
+  const { totalViews, allPageViews, isError, isLoading, lastUpdated, refresh } = usePageViews()
   const posts = getAllPosts()
   const series = getAllSeries()
   const tags = getAllTags()
@@ -123,7 +123,17 @@ export function AnalyticsPage() {
     <div className="max-w-4xl mx-auto">
       <section className="mb-8">
         <h1 className="text-4xl font-bold tracking-tight mb-2">{t.common.analytics}</h1>
-        <p className="text-muted-foreground">{t.analytics.description}</p>
+        <div className="flex items-center gap-2">
+          <p className="text-muted-foreground flex-1">{t.analytics.description}</p>
+          <button
+            onClick={refresh}
+            disabled={isLoading}
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`size-3.5 ${isLoading ? "animate-spin" : ""}`} />
+            {t.analytics.refresh}
+          </button>
+        </div>
         {isError && (
           <div className="mt-3 flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
             <AlertCircle className="size-4 shrink-0" />

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -41,7 +41,7 @@ import { SeriesNavigator } from "@/components/SeriesNavigator"
 import { AlertCircle, ArrowLeft, ArrowRight, Clock, Eye } from "lucide-react"
 import { useMetaTags } from "@/hooks/useMetaTags"
 import { usePageViews } from "@/hooks/usePageViews"
-import { analytics } from "@/lib/analytics"
+import { analytics, trackPageVisit } from "@/lib/analytics"
 import { useT } from "@/i18n"
 
 export function PostPage() {
@@ -66,6 +66,7 @@ export function PostPage() {
   useEffect(() => {
     if (post && slug) {
       analytics.viewPost(post.title, slug)
+      trackPageVisit(`/posts/${slug}`)
     }
   }, [slug]) // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
- Add Apps Script doPost for realtime page visit tracking via Google Sheets
- Merge Sheets (realtime counts) + GA4 (daily analytics) in unified doGet response
- Add CacheService 5min cache and path normalization to Apps Script
- Add trackPageVisit() using sendBeacon with session dedup
- Fix daily chart bug (unified response eliminates missing type param)
- Reduce client cache TTL from 1h to 15min, add refresh() method
- Add refresh button with spin animation to AnalyticsPage
- Extract API URL to VITE_GA_API_URL environment variable
- Add bot filtering for visitor tracking