### PR TITLE
fix: improve TOC scroll tracking and UX

### DIFF
--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useT } from "@/i18n"
@@ -13,6 +13,11 @@ export function TableOfContents({ containerSelector = ".prose" }: { containerSel
   const [headings, setHeadings] = useState<TocItem[]>([])
   const [activeId, setActiveId] = useState<string>("")
   const [open, setOpen] = useState(true)
+  const [progress, setProgress] = useState(0)
+  const [indicator, setIndicator] = useState({ top: 0, height: 0, visible: false })
+  const listRef = useRef<HTMLDivElement>(null)
+  const activeRef = useRef<HTMLAnchorElement>(null)
+  const ulRef = useRef<HTMLUListElement>(null)
   const t = useT()
 
   useEffect(() => {
@@ -35,8 +40,8 @@ export function TableOfContents({ containerSelector = ".prose" }: { containerSel
     if (headings.length === 0) return
 
     function onScroll() {
-      const offset = 80
-      let current = headings[0]?.id ?? ""
+      const offset = 100
+      let current = ""
       for (const heading of headings) {
         const el = document.getElementById(heading.id)
         if (el && el.getBoundingClientRect().top <= offset) {
@@ -44,6 +49,17 @@ export function TableOfContents({ containerSelector = ".prose" }: { containerSel
         }
       }
       setActiveId(current)
+
+      // Reading progress
+      const prose = document.querySelector(containerSelector)
+      if (prose) {
+        const rect = prose.getBoundingClientRect()
+        const total = rect.height - window.innerHeight
+        if (total > 0) {
+          const scrolled = Math.min(Math.max(-rect.top / total, 0), 1)
+          setProgress(scrolled)
+        }
+      }
     }
 
     onScroll()
@@ -51,33 +67,83 @@ export function TableOfContents({ containerSelector = ".prose" }: { containerSel
     return () => window.removeEventListener("scroll", onScroll)
   }, [headings])
 
+  useEffect(() => {
+    const container = listRef.current
+    const active = activeRef.current
+    const ul = ulRef.current
+    if (!container || !active || !ul) {
+      setIndicator((prev) => ({ ...prev, visible: false }))
+      return
+    }
+
+    const containerRect = container.getBoundingClientRect()
+    const activeRect = active.getBoundingClientRect()
+
+    // Auto-scroll TOC list
+    if (activeRect.top < containerRect.top) {
+      container.scrollTop += activeRect.top - containerRect.top - 8
+    } else if (activeRect.bottom > containerRect.bottom) {
+      container.scrollTop += activeRect.bottom - containerRect.bottom + 8
+    }
+
+    // Update indicator position relative to ul
+    const ulRect = ul.getBoundingClientRect()
+    setIndicator({
+      top: activeRect.top - ulRect.top,
+      height: activeRect.height,
+      visible: true,
+    })
+  }, [activeId])
+
   if (headings.length === 0) return null
 
   return (
     <nav className="hidden xl:block" aria-label="Table of contents">
       <div className="sticky top-20">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="gap-1.5 -ml-2 mb-3"
-          onClick={() => setOpen(!open)}
-          aria-expanded={open}
-          aria-label={t.components.tableOfContents}
-        >
-          <ChevronRight
-            className={`size-4 transition-transform duration-200 ${open ? "rotate-90" : ""}`}
-          />
-          {t.components.tableOfContents}
-        </Button>
+        <div className="flex items-center gap-2 mb-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 -ml-2 shrink-0"
+            onClick={() => setOpen(!open)}
+            aria-expanded={open}
+            aria-label={t.components.tableOfContents}
+          >
+            <ChevronRight
+              className={`size-4 transition-transform duration-200 ${open ? "rotate-90" : ""}`}
+            />
+            {t.components.tableOfContents}
+          </Button>
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <div className="h-1 rounded-full bg-muted flex-1 overflow-hidden">
+              <div
+                className="h-full bg-primary rounded-full transition-[width] duration-150 ease-out"
+                style={{ width: `${Math.round(progress * 100)}%` }}
+              />
+            </div>
+            <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+              {Math.round(progress * 100)}%
+            </span>
+          </div>
+        </div>
         <div
           className="grid transition-[grid-template-rows] duration-200 ease-in-out"
           style={{ gridTemplateRows: open ? "1fr" : "0fr" }}
         >
-          <div className="overflow-hidden">
-            <ul className="space-y-1.5 text-sm border-l">
+          <div ref={listRef} className="overflow-y-auto max-h-[calc(100vh-8rem)] scrollbar-thin">
+            <ul ref={ulRef} className="relative space-y-1.5 text-sm border-l">
+              <span
+                className="absolute left-0 w-0.5 bg-primary rounded-full transition-all duration-200 ease-out"
+                style={{
+                  top: indicator.top,
+                  height: indicator.height,
+                  opacity: indicator.visible ? 1 : 0,
+                }}
+              />
               {headings.map((heading) => (
                 <li key={heading.id}>
                   <a
+                    ref={activeId === heading.id ? activeRef : undefined}
                     href={`#${heading.id}`}
                     onClick={(e) => {
                       e.preventDefault()
@@ -87,7 +153,7 @@ export function TableOfContents({ containerSelector = ".prose" }: { containerSel
                       heading.level === 3 ? "pl-6" : "pl-3"
                     } ${
                       activeId === heading.id
-                        ? "text-primary font-medium border-l-2 border-primary -ml-px"
+                        ? "text-primary font-medium"
                         : "text-muted-foreground"
                     }`}
                   >

--- a/src/index.css
+++ b/src/index.css
@@ -251,6 +251,34 @@
   to { opacity: 1; }
 }
 
+/* TOC scrollbar: hidden by default, thin on hover */
+.scrollbar-thin {
+  scrollbar-width: none;
+}
+.scrollbar-thin:hover {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.scrollbar-thin::-webkit-scrollbar {
+  width: 0;
+}
+.scrollbar-thin:hover::-webkit-scrollbar {
+  width: 4px;
+}
+.scrollbar-thin:hover::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+.scrollbar-thin:hover::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* Prose heading scroll offset for sticky header */
+.prose h2,
+.prose h3 {
+  scroll-margin-top: 5rem;
+}
+
 /* Markdown prose code blocks */
 .prose pre {
   @apply bg-secondary text-secondary-foreground rounded-lg overflow-x-auto;


### PR DESCRIPTION
## Summary
- TOC 활성 헤딩 감지 오프셋을 sticky 헤더에 맞게 조정하여 스크롤 시 하이라이트 정확도 개선
- prose 헤딩에 `scroll-margin-top` 추가로 TOC 클릭 시 헤딩이 헤더 뒤에 가려지는 문제 수정
- TOC 목록 독립 스크롤 + 활성 항목 자동 추적, 애니메이션 인디케이터 바, 읽기 진행률 표시 추가

## Test plan
- [ ] 긴 목차가 있는 포스트에서 스크롤 시 TOC 하이라이트가 현재 섹션과 정확히 일치하는지 확인
- [ ] TOC 항목 클릭 시 헤딩이 sticky 헤더 아래에 올바르게 위치하는지 확인
- [ ] TOC 목록이 길 때 독립 스크롤이 동작하고, 페이지 본문 스크롤에 영향을 주지 않는지 확인
- [ ] 인디케이터 바가 항목 간 부드럽게 이동하는지 확인
- [ ] 읽기 진행률 바와 퍼센트가 스크롤에 따라 정확히 업데이트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)