### PR TITLE
feat: add confetti easter egg

### DIFF
--- a/src/components/Confetti.tsx
+++ b/src/components/Confetti.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef } from "react"
+
+interface Particle {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  color: string
+  size: number
+  rotation: number
+  rotationSpeed: number
+  opacity: number
+}
+
+const COLORS = [
+  "#ff577f", "#ff884b", "#ffd384", "#fff9b0",
+  "#3ec1d3", "#7c83fd", "#a66cff", "#59ce8f",
+]
+
+const PARTICLES_PER_BURST = 100
+const GRAVITY = 0.12
+const DURATION = 3500
+const BURST_ORIGINS = [0.25, 0.5, 0.75]
+const BURST_DELAYS = [0, 300, 600]
+const SECRET_SEQUENCE = ["KeyP", "KeyA", "KeyR", "KeyT", "KeyY"]
+const SEQUENCE_TIMEOUT = 2000
+
+export function Confetti() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const bufferRef = useRef("")
+  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) return
+
+      clearTimeout(timerRef.current)
+      bufferRef.current += e.code + ","
+
+      if (bufferRef.current.split(",").filter(Boolean).slice(-SECRET_SEQUENCE.length).join(",") === SECRET_SEQUENCE.join(",")) {
+        bufferRef.current = ""
+        fireConfetti()
+        return
+      }
+
+      timerRef.current = setTimeout(() => {
+        bufferRef.current = ""
+      }, SEQUENCE_TIMEOUT)
+    }
+
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.removeEventListener("keydown", onKeyDown)
+      clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  function fireConfetti() {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    canvas.width = window.innerWidth
+    canvas.height = window.innerHeight
+    canvas.style.display = "block"
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    interface Burst { particles: Particle[]; startTime: number }
+    const bursts: Burst[] = []
+    const globalStart = performance.now()
+
+    function spawnBurst(originX: number) {
+      const particles: Particle[] = Array.from({ length: PARTICLES_PER_BURST }, () => ({
+        x: originX,
+        y: window.innerHeight * 0.55,
+        vx: (Math.random() - 0.5) * 16,
+        vy: Math.random() * -14 - 4,
+        color: COLORS[Math.floor(Math.random() * COLORS.length)],
+        size: Math.random() * 8 + 4,
+        rotation: Math.random() * Math.PI * 2,
+        rotationSpeed: (Math.random() - 0.5) * 0.2,
+        opacity: 1,
+      }))
+      bursts.push({ particles, startTime: performance.now() })
+    }
+
+    BURST_ORIGINS.forEach((ratio, i) => {
+      setTimeout(() => spawnBurst(window.innerWidth * ratio), BURST_DELAYS[i])
+    })
+
+    function animate(now: number) {
+      const globalElapsed = now - globalStart
+      const totalDuration = DURATION + BURST_DELAYS[BURST_DELAYS.length - 1]
+      if (globalElapsed > totalDuration) {
+        ctx!.clearRect(0, 0, canvas!.width, canvas!.height)
+        canvas!.style.display = "none"
+        return
+      }
+
+      ctx!.clearRect(0, 0, canvas!.width, canvas!.height)
+
+      for (const burst of bursts) {
+        const elapsed = now - burst.startTime
+        const fadeStart = DURATION * 0.6
+        for (const p of burst.particles) {
+          p.x += p.vx
+          p.vy += GRAVITY
+          p.y += p.vy
+          p.vx *= 0.99
+          p.rotation += p.rotationSpeed
+
+          if (elapsed > fadeStart) {
+            p.opacity = Math.max(0, 1 - (elapsed - fadeStart) / (DURATION - fadeStart))
+          }
+
+          ctx!.save()
+          ctx!.translate(p.x, p.y)
+          ctx!.rotate(p.rotation)
+          ctx!.globalAlpha = p.opacity
+          ctx!.fillStyle = p.color
+          ctx!.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2)
+          ctx!.restore()
+        }
+      }
+
+      requestAnimationFrame(animate)
+    }
+
+    requestAnimationFrame(animate)
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="fixed inset-0 z-[9999] pointer-events-none"
+      style={{ display: "none" }}
+    />
+  )
+}

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -42,6 +42,7 @@ export function KeyboardShortcuts() {
     { keys: [isMac ? "\u2318" : "Ctrl", "K"], description: t.components.shortcutSearch },
     { keys: [isMac ? "\u2318" : "Ctrl", "B"], description: t.components.shortcutSidebar },
     { keys: ["Shift", "/"], description: t.components.shortcutHelp },
+    { keys: ["?", "?", "?", "?", "?"], description: "???" },
   ]
 
   return (

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -4,11 +4,13 @@ import { AppSidebar } from "@/components/Sidebar"
 import { ScrollToTop } from "@/components/ScrollToTop"
 import { SearchCommand } from "@/components/SearchCommand"
 import { ScrollToTopButton } from "@/components/ScrollToTopButton"
+import { Confetti } from "@/components/Confetti"
 
 export function RootLayout() {
   return (
     <SidebarProvider>
       <ScrollToTop />
+      <Confetti />
       <AppSidebar />
       <SidebarInset>
         <header className="sticky top-0 z-40 flex h-14 items-center gap-2 bg-background px-4">


### PR DESCRIPTION
## Summary
- 블로그 아무 페이지에서 `party`를 타이핑하면 confetti 폭죽 3연발이 터지는 이스터에그 추가
- 키보드 단축키 모달에 `??? → ???` 힌트 표시
- Canvas API 기반 자체 구현 (외부 라이브러리 없음), 한글 IME에서도 동작

## Test plan
- [ ] 블로그 페이지에서 `p-a-r-t-y` 키 입력 시 confetti 발동 확인
- [ ] 한글 IME 상태에서도 동작 확인
- [ ] `?` 키로 단축키 모달 열어 `???` 항목 표시 확인
- [ ] input/textarea 내에서는 발동하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)