### PR TITLE
fix: use PAT for release-please auto-merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,5 +21,6 @@ jobs:
         if: steps.release.outputs.pr
         run: gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           GH_REPO: ${{ github.repository }}
+


### PR DESCRIPTION
## Summary
- release-please의 auto-merge에서 `GITHUB_TOKEN` 대신 `PAT_TOKEN`을 사용하도록 변경
- `GITHUB_TOKEN`으로 머지 시 후속 워크플로우가 트리거되지 않아 GitHub Release/태그가 생성되지 않던 문제 해결 (v1.3.1 누락 원인)

## Test plan
- [ ] GitHub repo secrets에 `PAT_TOKEN` 등록 확인
- [ ] 이 PR 머지 후 release-please가 v1.3.1 릴리즈를 정상 생성하는지 확인
- [ ] 이후 feat/fix 커밋 시 릴리즈 PR 자동 머지 → GitHub Release 생성 흐름 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)