### PR TITLE
fix: 모바일 Safari PDF 다운로드 오류 수정

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -150,11 +150,16 @@ export function AboutPage() {
       ])
       const blob = await pdf(ResumePdfDocument()).toBlob()
       const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `${PROFILE.name}_이력서.pdf`
-      a.click()
-      URL.revokeObjectURL(url)
+      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
+      if (isIOS) {
+        window.open(url, "_blank")
+      } else {
+        const a = document.createElement("a")
+        a.href = url
+        a.download = `${PROFILE.name}_이력서.pdf`
+        a.click()
+      }
+      setTimeout(() => URL.revokeObjectURL(url), 60_000)
     } finally {
       setPdfLoading(false)
     }


### PR DESCRIPTION
## Summary
- 모바일 Safari에서 PDF 다운로드 시 `webkitBlobResource error 1` 오류 수정
- iOS에서는 Blob URL을 `window.open()`으로 새 탭에서 열도록 변경
- `revokeObjectURL`을 60초 지연하여 브라우저가 Blob을 읽기 전 해제되는 문제 방지

## Test plan
- [ ] iOS Safari에서 About 페이지 PDF 버튼 클릭 시 새 탭에서 PDF 정상 표시 확인
- [ ] 데스크톱 브라우저에서 기존대로 PDF 파일 다운로드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)