### PR TITLE
fix: iOS에서 navigator.share()로 PDF 파일 저장 지원

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -149,17 +149,18 @@ export function AboutPage() {
         import("@/components/ResumePdf"),
       ])
       const blob = await pdf(ResumePdfDocument()).toBlob()
-      const url = URL.createObjectURL(blob)
-      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
-      if (isIOS) {
-        window.open(url, "_blank")
+      const fileName = `${PROFILE.name}_이력서.pdf`
+      const file = new File([blob], fileName, { type: "application/pdf" })
+      if (navigator.canShare?.({ files: [file] })) {
+        await navigator.share({ files: [file] })
       } else {
+        const url = URL.createObjectURL(blob)
         const a = document.createElement("a")
         a.href = url
-        a.download = `${PROFILE.name}_이력서.pdf`
+        a.download = fileName
         a.click()
+        setTimeout(() => URL.revokeObjectURL(url), 60_000)
       }
-      setTimeout(() => URL.revokeObjectURL(url), 60_000)
     } finally {
       setPdfLoading(false)
     }


### PR DESCRIPTION
window.open() 대신 Web Share API를 사용하여 iOS 네이티브 공유 시트에서 파일 저장이 가능하도록 변경. canShare 미지원 브라우저는 기존 다운로드 방식 유지.