### PR TITLE
fix: 모바일 Safari PDF 다운로드 - 데스크탑 공유시트 문제 수정

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -151,7 +151,8 @@ export function AboutPage() {
       const blob = await pdf(ResumePdfDocument()).toBlob()
       const fileName = `${PROFILE.name}_이력서.pdf`
       const file = new File([blob], fileName, { type: "application/pdf" })
-      if (navigator.canShare?.({ files: [file] })) {
+      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+      if (isMobile && navigator.canShare?.({ files: [file] })) {
         await navigator.share({ files: [file] })
       } else {
         const url = URL.createObjectURL(blob)


### PR DESCRIPTION
## Summary
- 데스크탑 Safari에서 PDF 다운로드 시 공유 시트가 뜨는 문제 수정
- 모바일 기기에서만 `navigator.share()` 사용, 데스크탑은 기존 다운로드 방식 유지

## Test plan
- [ ] iOS Safari에서 PDF 버튼 클릭 → 공유 시트 → "파일에 저장" 정상 동작
- [ ] 데스크탑 브라우저에서 PDF 버튼 클릭 → 파일 바로 다운로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)