### PR TITLE
fix: Windows/Android PDF 다운로드 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ npm-debug.log*
 *.sln
 *.sw?
 .omc
+.superset
 
 tsconfig.app.tsbuildinfo
 tsconfig.node.tsbuildinfo

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -150,18 +150,32 @@ export function AboutPage() {
       ])
       const blob = await pdf(ResumePdfDocument()).toBlob()
       const fileName = `${PROFILE.name}_이력서.pdf`
-      const file = new File([blob], fileName, { type: "application/pdf" })
+      const url = URL.createObjectURL(blob)
+
       const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-      if (isMobile && navigator.canShare?.({ files: [file] })) {
-        await navigator.share({ files: [file] })
+      if (isMobile) {
+        const file = new File([blob], fileName, { type: "application/pdf" })
+        if (navigator.canShare?.({ files: [file] })) {
+          try {
+            await navigator.share({ files: [file] })
+            return
+          } catch {
+            // User cancelled or share failed — fall through
+          }
+        }
+        // Android 등 share 미지원 모바일: 새 탭에서 PDF 열기
+        window.open(url, "_blank")
       } else {
-        const url = URL.createObjectURL(blob)
+        // Desktop (Windows/Mac/Linux): DOM에 추가 후 클릭해야 모든 브라우저에서 동작
         const a = document.createElement("a")
         a.href = url
         a.download = fileName
+        document.body.appendChild(a)
         a.click()
-        setTimeout(() => URL.revokeObjectURL(url), 60_000)
+        document.body.removeChild(a)
       }
+
+      setTimeout(() => URL.revokeObjectURL(url), 60_000)
     } finally {
       setPdfLoading(false)
     }


### PR DESCRIPTION
## Summary
- **Windows**: `<a>` 요소를 DOM에 추가 후 click하여 Firefox 등 모든 브라우저에서 다운로드 동작하도록 수정
- **Android**: `navigator.share` 미지원 시 `window.open` fallback으로 새 탭에서 PDF를 열 수 있도록 수정
- **iOS**: `navigator.share` 실패 시에도 `window.open` fallback 적용

## Test plan
- [ ] Windows Chrome/Firefox/Edge에서 PDF 다운로드 확인
- [ ] Android Chrome에서 PDF 다운로드(새 탭 열림) 확인
- [ ] iOS Safari에서 navigator.share 동작 확인
- [ ] Mac Desktop에서 기존 다운로드 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)