### PR TITLE
fix: 홈 인기글에 draft/hidden 포스트 노출 버그 수정

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -24,9 +24,10 @@ export function HomePage() {
       .map(([path, views]) => {
         const slug = path.replace("/posts/", "").replace(/\/$/, "")
         const post = posts.find((p) => p.slug === slug)
-        return { slug, title: post?.title ?? slug, views, draft: post?.draft }
+        if (!post) return null
+        return { slug, title: post.title, views }
       })
-      .filter((p) => !p.draft)
+      .filter((p): p is NonNullable<typeof p> => p !== null)
       .sort((a, b) => b.views - a.views)
       .slice(0, 5)
   }, [allPageViews, posts])


### PR DESCRIPTION
## Summary
- 홈 Popular Posts에 draft/hidden 포스트(예: test-post)가 노출되던 버그 수정
- GA API 조회수 데이터 기반으로 인기글을 만들 때, `getAllPosts()`에 없는 글(draft, 예약발행)이 `post?.draft → undefined → falsy`로 필터를 통과하던 문제
- `post` 매칭 실패 시 `null` 반환 후 필터링하도록 변경하여, `getAllPosts()`의 `isHidden()` 로직을 자연스럽게 활용

## Test plan
- [ ] 개발 서버에서 draft 포스트가 Popular Posts에 노출되지 않는지 확인
- [ ] production 빌드에서 hidden 포스트가 Popular Posts에 노출되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)