### PR TITLE
feat: Spring AI 적용 가이드 시리즈 초안 추가

### DIFF
--- a/content/posts/spring-ai-guide-01-setup.md
+++ b/content/posts/spring-ai-guide-01-setup.md
@@ -1,0 +1,262 @@
+---
+title: "Spring AI 적용 가이드 (1) - 프로젝트 설정부터 첫 번째 AI 호출까지"
+date: "2026-03-17"
+description: "Spring AI의 핵심 개념과 프로젝트 설정, ChatClient를 이용한 첫 번째 AI 호출까지를 정리합니다."
+tags: ["spring-ai", "spring-boot", "ai", "llm", "java"]
+series: "Spring AI 적용 가이드"
+seriesOrder: 1
+draft: true
+---
+
+## 들어가며
+
+이전에 [Spring AI 실전 적용기](/posts/spring-ai-pipeline-real-world)에서 7단계 AI 진단 파이프라인을 구축한 경험을 공유했다. 그 글은 "무엇을 만들었는가"에 초점이 맞춰져 있었는데, 이번 시리즈에서는 **"어떻게 Spring AI를 프로젝트에 적용하는가"**를 단계별로 정리하려 한다.
+
+Spring AI를 처음 도입하려는 분들이 빠르게 시작할 수 있도록, 실제 프로덕션 코드를 기반으로 설명한다.
+
+## Spring AI란
+
+[Spring AI](https://spring.io/projects/spring-ai)는 Spring 팀이 공식으로 개발하는 AI 통합 프레임워크다. Python 생태계의 LangChain과 비슷한 위치에 있지만, 접근 방식이 다르다.
+
+Spring AI의 핵심 철학은 **"기존 Spring 개발 경험을 그대로 쓸 수 있게"** 하는 것이다. 의존성 주입, 자동 설정, 프로퍼티 바인딩 같은 Spring Boot의 장점을 AI 영역에서도 동일하게 활용할 수 있다.
+
+```mermaid
+flowchart LR
+    subgraph "Spring AI 추상화"
+        CC["ChatClient"]
+        CM["ChatModel"]
+    end
+
+    CC --> CM
+    CM --> O["OpenAI"]
+    CM --> B["AWS Bedrock"]
+    CM --> G["Google Gemini"]
+    CM --> A["Anthropic"]
+    CM --> etc["..."]
+```
+
+가장 큰 장점은 **ChatModel 인터페이스 추상화**다. OpenAI, AWS Bedrock, Google Gemini 등 서로 다른 LLM 프로바이더를 동일한 인터페이스로 호출할 수 있다. 프로바이더마다 다른 API 스펙, 인증 방식, 요청/응답 포맷을 각각 대응할 필요가 없다.
+
+## 의존성 설정
+
+### Gradle (Kotlin DSL)
+
+Spring AI는 프로바이더별로 별도의 starter 의존성을 제공한다. 사용할 프로바이더만 추가하면 된다.
+
+```kotlin
+// build.gradle.kts
+val aiVersion = "1.1.0"
+
+dependencies {
+    // OpenAI (GPT 모델)
+    implementation("org.springframework.ai:spring-ai-starter-model-openai:${aiVersion}")
+
+    // AWS Bedrock (Claude, Llama, Mistral 등)
+    implementation("org.springframework.ai:spring-ai-starter-model-bedrock-converse:${aiVersion}")
+
+    // Google Gemini
+    implementation("org.springframework.ai:spring-ai-starter-model-google-genai:${aiVersion}")
+}
+```
+
+> **참고**: Spring AI 1.0부터 artifact 이름이 변경됐다. 이전의 `spring-ai-openai-spring-boot-starter`가 `spring-ai-starter-model-openai`로 바뀌었으니 주의하자.
+
+한 프로바이더만 쓴다면 해당 의존성 하나만 추가하면 된다. 우리는 세 개를 모두 사용하고 있지만, 처음 시작한다면 OpenAI 하나부터 시작하는 걸 추천한다.
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-openai</artifactId>
+    <version>1.1.0</version>
+</dependency>
+```
+
+## application.yml 설정
+
+의존성을 추가하면 Spring Boot 자동 설정이 동작한다. `application.yml`에 API 키와 기본 옵션만 설정하면 된다.
+
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          temperature: 1.0
+```
+
+이게 전부다. Spring Boot가 이 설정을 읽어서 `OpenAiChatModel` 빈을 자동으로 생성해준다.
+
+### 타임아웃 설정
+
+LLM 호출은 일반적인 API 호출보다 응답 시간이 길다. 기본 타임아웃이 짧으면 긴 응답이 중간에 끊길 수 있으므로, 충분히 여유를 두는 게 좋다.
+
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          temperature: 1.0
+    timeout:
+      connect: 60s
+      read: 300s
+```
+
+우리는 connect 60초, read 5분으로 설정하고 있다. 특히 read 타임아웃은 LLM이 긴 응답을 생성할 때를 고려해서 넉넉하게 잡아야 한다.
+
+## ChatClient vs ChatModel
+
+Spring AI에는 두 가지 핵심 인터페이스가 있다. 차이를 이해하는 게 중요하다.
+
+### ChatModel
+
+`ChatModel`은 LLM 프로바이더와의 저수준 인터페이스다. 프로바이더별로 구현체가 있다.
+
+```java
+// 각 프로바이더의 ChatModel 구현체
+OpenAiChatModel       // OpenAI
+BedrockProxyChatModel  // AWS Bedrock
+GoogleGenAiChatModel   // Google Gemini
+```
+
+Spring Boot 자동 설정으로 해당 프로바이더의 `ChatModel` 빈이 자동 등록된다. 직접 사용할 수도 있지만, 일반적으로는 `ChatClient`를 통해 사용한다.
+
+### ChatClient
+
+`ChatClient`는 `ChatModel` 위에 구축된 고수준 fluent API다. 프롬프트 구성, 옵션 설정, 응답 처리를 메서드 체이닝으로 간결하게 작성할 수 있다.
+
+```java
+// ChatModel을 감싸서 ChatClient 생성
+ChatClient chatClient = ChatClient.create(openAiChatModel);
+```
+
+**어떤 걸 써야 하나?** 대부분의 경우 `ChatClient`를 쓰면 된다. `ChatModel`은 커스텀 어드바이저나 저수준 제어가 필요할 때 직접 접근한다.
+
+## 첫 번째 AI 호출
+
+### 1. ChatClient Bean 등록
+
+```java
+@Configuration
+public class ChatClientConfig {
+
+    @Bean("openaiChatClient")
+    public ChatClient openaiChatClient(OpenAiChatModel chatModel) {
+        return ChatClient.create(chatModel);
+    }
+}
+```
+
+Spring Boot가 `OpenAiChatModel`을 자동 생성하고, 우리는 그걸로 `ChatClient`를 만든다.
+
+> **`spring.ai.chat.client.enabled`** 를 `false`로 설정하면 Spring AI가 자동으로 ChatClient 빈을 만들지 않는다. 여러 프로바이더를 사용할 때는 이렇게 자동 생성을 끄고, 위처럼 직접 Bean으로 등록하는 게 깔끔하다.
+
+```yaml
+spring:
+  ai:
+    chat:
+      client:
+        enabled: false  # ChatClient 자동 생성 비활성화
+```
+
+### 2. 서비스에서 호출
+
+```java
+@Service
+@RequiredArgsConstructor
+public class AiService {
+
+    @Qualifier("openaiChatClient")
+    private final ChatClient chatClient;
+
+    public String ask(String question) {
+        return chatClient.prompt()
+                .user(question)
+                .call()
+                .content();
+    }
+}
+```
+
+`chatClient.prompt()`로 요청을 시작하고, `.user()`로 사용자 메시지를 설정하고, `.call()`로 호출하고, `.content()`로 응답 텍스트를 꺼낸다.
+
+### 3. System Prompt 추가
+
+시스템 프롬프트를 추가해서 LLM의 역할과 응답 스타일을 지정할 수 있다.
+
+```java
+public ChatResponse chat(String systemPrompt, String userPrompt) {
+    ChatClient.ChatClientRequestSpec ai = chatClient.prompt();
+
+    if (systemPrompt != null && !systemPrompt.isEmpty()) ai.system(systemPrompt);
+    if (userPrompt != null && !userPrompt.isEmpty()) ai.user(userPrompt);
+
+    return ai.call()
+            .chatClientResponse()
+            .chatResponse();
+}
+```
+
+### 4. ChatResponse로 메타데이터 접근
+
+단순 텍스트가 아니라 토큰 사용량 같은 메타데이터가 필요하면 `ChatResponse`를 사용한다. `ChatResponse`에는 모델 응답 텍스트 외에도 사용된 토큰 수, 모델 정보, finish reason 등이 포함된다.
+
+```java
+ChatResponse response = ai.call()
+        .chatClientResponse()
+        .chatResponse();
+
+// 응답 텍스트
+String text = response.getResults().stream()
+        .filter(r -> r.getOutput().getText() != null)
+        .findFirst()
+        .map(r -> r.getOutput().getText())
+        .orElseThrow();
+
+// 토큰 사용량 등 메타데이터도 접근 가능
+```
+
+## 프로젝트 구조
+
+실제 프로덕션에서 Spring AI 관련 코드를 어떻게 구성하는지도 중요하다. 우리 프로젝트의 구조를 참고로 공유한다.
+
+```
+src/main/java/
+├── modules/ai/                       # AI 인프라 레이어
+│   ├── config/
+│   │   ├── ChatClientConfig.java     # ChatClient Bean 등록
+│   │   └── ClientConfig.java         # HTTP 클라이언트 설정
+│   ├── client/
+│   │   ├── OpenAiClient.java         # OpenAI REST 클라이언트
+│   │   └── GeminiClient.java         # Gemini REST 클라이언트
+│   ├── properties/
+│   │   └── AiTimeoutProperties.java  # 타임아웃 설정
+│   └── dto/
+│       └── ...                       # 응답 DTO
+├── applications/ai/                  # AI 비즈니스 레이어
+│   ├── controller/
+│   │   └── AiController.java         # API 엔드포인트
+│   ├── service/
+│   │   └── AiService.java            # AI 호출 서비스
+│   └── dto/
+│       └── ChatRequest.java          # 요청 DTO
+```
+
+`modules/ai`에는 Spring AI 인프라 설정을, `applications/ai`에는 비즈니스 로직을 분리했다. AI 기능이 확장되더라도 설정과 비즈니스 로직이 섞이지 않는다.
+
+## 정리
+
+이번 편에서는 Spring AI 프로젝트 설정과 기본적인 ChatClient 사용법을 다뤘다. 핵심을 요약하면:
+
+- Spring AI는 Spring Boot 자동 설정과 완전히 통합된다
+- 의존성 추가 + `application.yml` 설정만으로 바로 시작할 수 있다
+- `ChatModel`(저수준) 위에 `ChatClient`(고수준 fluent API)를 사용한다
+- 여러 프로바이더를 쓸 때는 `spring.ai.chat.client.enabled: false`로 자동 생성을 끄고 직접 Bean으로 등록한다
+
+[다음 편](/posts/spring-ai-guide-02-multi-provider)에서는 OpenAI, AWS Bedrock, Google Gemini 세 가지 프로바이더를 동시에 지원하는 멀티 프로바이더 전략을 다룬다.

--- a/content/posts/spring-ai-guide-02-multi-provider.md
+++ b/content/posts/spring-ai-guide-02-multi-provider.md
@@ -1,0 +1,348 @@
+---
+title: "Spring AI 적용 가이드 (2) - 멀티 프로바이더 전략"
+date: "2026-03-17"
+description: "OpenAI, AWS Bedrock, Google Gemini를 하나의 ChatClient 인터페이스로 추상화하고, 런타임에 동적으로 전환하는 방법을 다룹니다."
+tags: ["spring-ai", "spring-boot", "ai", "openai", "bedrock", "gemini"]
+series: "Spring AI 적용 가이드"
+seriesOrder: 2
+draft: true
+---
+
+## 왜 멀티 프로바이더인가
+
+처음에는 OpenAI 하나만 사용했다. 그런데 프로덕션에서 운영하다 보면 단일 프로바이더에 의존하는 게 리스크라는 걸 금방 깨닫게 된다.
+
+- **비용**: 모든 작업에 고성능 모델을 쓸 필요가 없다. 단순한 작업에는 저비용 모델로 충분하다
+- **성능**: 같은 작업이라도 프로바이더마다 응답 품질과 속도가 다르다
+- **가용성**: 한 프로바이더에 장애가 나면 다른 프로바이더로 전환할 수 있어야 한다
+- **규제**: 데이터 주권 요구사항에 따라 특정 리전의 모델만 사용해야 할 수도 있다
+
+Spring AI의 `ChatModel` 추상화가 이 문제를 깔끔하게 해결해준다.
+
+```mermaid
+flowchart TB
+    subgraph "Application Layer"
+        AS["AiService"]
+    end
+
+    subgraph "Spring AI Abstraction"
+        CC1["openaiChatClient"]
+        CC2["bedrockChatClient"]
+        CC3["genAiChatClient"]
+    end
+
+    subgraph "Providers"
+        O["OpenAI<br/>GPT 시리즈"]
+        B["AWS Bedrock<br/>Claude, Llama, Mistral..."]
+        G["Google Gemini<br/>Gemini 시리즈"]
+    end
+
+    AS -->|"provider=openai"| CC1
+    AS -->|"provider=bedrock"| CC2
+    AS -->|"provider=gemini"| CC3
+    CC1 --> O
+    CC2 --> B
+    CC3 --> G
+```
+
+## 프로바이더별 설정
+
+### application.yml
+
+각 프로바이더의 인증 정보와 기본 옵션을 설정한다.
+
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          temperature: 1.0
+
+    google:
+      genai:
+        api-key: ${GOOGLE_AI_API_KEY}
+
+    bedrock:
+      aws:
+        region: ap-northeast-2
+
+    chat:
+      client:
+        enabled: false  # 자동 ChatClient 생성 비활성화
+```
+
+`chat.client.enabled: false`가 핵심이다. Spring AI는 기본적으로 하나의 `ChatClient` 빈을 자동 생성하는데, 멀티 프로바이더 환경에서는 이를 끄고 직접 등록해야 한다.
+
+### ChatClient Bean 등록
+
+```java
+@Configuration
+public class ChatClientConfig {
+
+    @Bean("openaiChatClient")
+    public ChatClient openaiChatClient(OpenAiChatModel chatModel) {
+        return ChatClient.create(chatModel);
+    }
+
+    @Bean("bedrockChatClient")
+    public ChatClient bedrockChatClient(BedrockProxyChatModel bedrockChatModel) {
+        return ChatClient.create(bedrockChatModel);
+    }
+
+    @Bean("genAiChatClient")
+    public ChatClient genAiChatClient(GoogleGenAiChatModel chatModel) {
+        return ChatClient.create(chatModel);
+    }
+}
+```
+
+패턴은 동일하다. 각 프로바이더의 `ChatModel` 구현체를 `ChatClient.create()`에 넘기기만 하면 된다. Spring Boot 자동 설정이 `OpenAiChatModel`, `GoogleGenAiChatModel`을 알아서 만들어주므로, 우리는 그걸 주입받기만 하면 된다.
+
+### Bedrock 별도 설정
+
+AWS Bedrock은 다른 프로바이더와 달리 `BedrockProxyChatModel`을 직접 빌드해야 한다. AWS 인증과 리전 설정이 필요하기 때문이다.
+
+```java
+@Bean
+public BedrockProxyChatModel bedrockChatModel() {
+    return BedrockProxyChatModel.builder()
+            .credentialsProvider(DefaultCredentialsProvider.builder().build())
+            .region(Region.AP_NORTHEAST_2)
+            .build();
+}
+```
+
+`DefaultCredentialsProvider`는 AWS의 기본 인증 체인(환경변수, EC2 인스턴스 프로파일, ECS 태스크 역할 등)을 따른다. 로컬에서는 `~/.aws/credentials`, 배포 환경에서는 IAM 역할을 자동으로 사용한다. 타임아웃 설정은 [4편](/posts/spring-ai-guide-04-production)에서 다룬다.
+
+## 프로바이더별 옵션 제어
+
+같은 `ChatClient`를 쓰더라도, 호출 시점에 프로바이더별 옵션을 세밀하게 제어할 수 있다.
+
+```java
+public ChatClient.ChatClientRequestSpec getAi(String provider, String model, String responseSchema) {
+    return switch (provider) {
+        case "openai" -> {
+            var builder = OpenAiChatOptions.builder().model(model);
+            if (StringUtils.hasText(responseSchema)) {
+                builder.responseFormat(ResponseFormat.builder()
+                        .type(ResponseFormat.Type.JSON_SCHEMA)
+                        .jsonSchema(responseSchema)
+                        .build());
+            }
+            yield openaiChatClient.prompt().options(builder.build());
+        }
+        case "gemini" ->
+            geminiChatClient.prompt()
+                .options(GoogleGenAiChatOptions.builder().model(model).build());
+        case "bedrock" ->
+            bedrockChatClient.prompt()
+                .options(BedrockChatOptions.builder().model(model).maxTokens(10000).build());
+        default -> throw new IllegalArgumentException("Unsupported provider: " + provider);
+    };
+}
+```
+
+각 프로바이더의 `ChatOptions` 구현체(`OpenAiChatOptions`, `GoogleGenAiChatOptions`, `BedrockChatOptions`)를 통해 모델명, temperature, maxTokens, responseFormat 등을 호출 시점에 동적으로 설정한다.
+
+여기서 주목할 점은 `application.yml`에서 설정한 기본값을 **호출 시점에 오버라이드**할 수 있다는 것이다. 기본 모델은 `gpt-4o-mini`지만, 특정 호출에서는 `gpt-4o`를 쓰고 싶다면 `.options()`에서 모델만 바꿔주면 된다.
+
+## Bedrock Cross-Region Inference
+
+AWS Bedrock에서 Claude, Llama 같은 모델을 사용할 때 **크로스 리전 추론(Cross-Region Inference)**을 활용하면, 특정 리전에 트래픽이 몰려도 다른 리전으로 자동 분산된다. 이를 위해 모델 ID에 리전 접두사를 붙여야 한다.
+
+```java
+private static final List<String> CROSS_REGION_MODEL_PREFIXES = List.of(
+        "anthropic.", "meta.", "mistral.", "cohere.", "ai21.", "stability."
+);
+
+private String resolveRegionAwareModelId(FoundationModelSummary summary, Region region) {
+    String modelId = extractModelId(summary.modelArn());
+    if (requiresRegionAlias(modelId)) {
+        return resolveCrossRegionAlias(region)
+                .map(prefix -> prefix + "." + modelId)
+                .orElse(modelId);
+    }
+    return modelId;
+}
+
+private Optional<String> resolveCrossRegionAlias(Region region) {
+    String regionId = region.id();
+    if (regionId.startsWith("ap-")) return Optional.of("apac");
+    if (regionId.startsWith("eu-")) return Optional.of("eu");
+    if (regionId.startsWith("us-") && !"us-west-2".equals(regionId)) return Optional.of("us");
+    return Optional.empty();
+}
+```
+
+예를 들어 `ap-northeast-2`(서울) 리전에서 `anthropic.claude-3-5-sonnet`을 사용하면, 모델 ID가 `apac.anthropic.claude-3-5-sonnet`으로 변환된다. 이러면 AWS가 아시아-태평양 리전 내에서 가용한 인스턴스로 자동 라우팅해준다.
+
+## 모델 자동 감지
+
+사용자가 모델 ID만 넘기면, 어떤 프로바이더의 모델인지 자동으로 감지하는 기능도 구현했다.
+
+```java
+public Optional<String> resolveProviderByModelId(String modelId) {
+    if (!StringUtils.hasText(modelId)) {
+        return Optional.empty();
+    }
+
+    if (modelCache.isEmpty()) {
+        refreshModelCacheSafely();
+    }
+
+    return modelCache.entrySet().stream()
+            .filter(entry -> entry.getValue().stream()
+                    .anyMatch(model -> model.equalsIgnoreCase(modelId)))
+            .map(Map.Entry::getKey)
+            .findFirst();
+}
+```
+
+각 프로바이더의 모델 목록을 캐싱해두고, 모델 ID로 어떤 프로바이더에 속하는지 탐색한다. 덕분에 프롬프트 설정에서 `modelId`만 지정하면 프로바이더는 자동으로 결정된다.
+
+### 모델 목록 캐싱
+
+```java
+@PostConstruct
+public void initializeModelCache() {
+    refreshModelCacheSafely();
+}
+
+private void refreshModelCache() {
+    Map<String, List<String>> snapshot = new LinkedHashMap<>();
+    snapshot.put("openai", safeList(getOpenAiModels()));
+    snapshot.put("bedrock", safeList(getBedrockModels()));
+    snapshot.put("gemini", safeList(getGeminiModels()));
+
+    modelCache.clear();
+    snapshot.forEach(modelCache::put);
+    log.info("model cache initialized providers={}", snapshot.keySet());
+}
+```
+
+애플리케이션 시작 시 `@PostConstruct`로 모든 프로바이더의 모델 목록을 조회해서 `ConcurrentHashMap`에 캐싱한다. 각 프로바이더는 자체 API로 모델 목록을 가져온다:
+
+| 프로바이더 | 모델 목록 조회 방식 |
+|------------|---------------------|
+| OpenAI | `GET /v1/models` (REST API) |
+| Bedrock | `listFoundationModels()` (AWS SDK) |
+| Gemini | Vertex AI Models API (REST + 페이지네이션) |
+
+## Gemini 인증 설정
+
+Google Gemini(Vertex AI)는 인증 설정이 조금 복잡하다. 서비스 계정 키 파일을 사용하고, 토큰이 만료되면 자동으로 갱신해야 한다.
+
+```java
+@Bean("geminiRestClient")
+public RestClient geminiRestClient() {
+    ClassPathResource resource = new ClassPathResource("google-credentials.json");
+    GoogleCredentials credentials = GoogleCredentials
+            .fromStream(resource.getInputStream())
+            .createScoped("https://www.googleapis.com/auth/cloud-platform");
+    credentials.refreshIfExpired();
+
+    return RestClient.builder()
+            .baseUrl("https://aiplatform.googleapis.com/v1beta1")
+            .requestInterceptor((request, body, execution) -> {
+                credentials.refreshIfExpired();  // 매 요청마다 토큰 갱신 확인
+                String token = credentials.getAccessToken().getTokenValue();
+                request.getHeaders().add("x-goog-user-project", projectId);
+                request.getHeaders().add("Authorization", "Bearer " + token);
+                return execution.execute(request, body);
+            })
+            .build();
+}
+```
+
+`requestInterceptor`에서 매 요청마다 `refreshIfExpired()`를 호출하는 게 핵심이다. Google 인증 토큰은 기본 1시간 만료인데, 장시간 운영하면서 토큰이 만료되면 401 에러가 발생한다. 인터셉터에서 자동 갱신하면 이 문제를 깔끔하게 해결할 수 있다.
+
+## 동적 프로바이더 라우팅
+
+지금까지 설정한 것들을 조합하면, 하나의 서비스 메서드로 어떤 프로바이더든 호출할 수 있다.
+
+```java
+public ChatResponse chat(ChatRequest chatRequest) {
+    String provider = chatRequest.provider().trim().toLowerCase();
+    ChatClient.ChatClientRequestSpec ai = getAi(provider, chatRequest.model(), chatRequest.responseSchema());
+
+    // 프롬프트 적용 (system, user, messages)
+    applyPrompts(ai, chatRequest);
+
+    return ai.call()
+            .responseEntity(new ParameterizedTypeReference<>() {})
+            .response();
+}
+```
+
+호출하는 쪽에서는 `provider`와 `model`만 지정하면 된다:
+
+```java
+// OpenAI GPT-4o-mini 호출
+ChatRequest.builder()
+    .provider("openai")
+    .model("gpt-4o-mini")
+    .userPrompt("Hello!")
+    .build();
+
+// AWS Bedrock Claude 호출
+ChatRequest.builder()
+    .provider("bedrock")
+    .model("apac.anthropic.claude-3-5-sonnet-20241022-v2:0")
+    .userPrompt("Hello!")
+    .build();
+
+// Google Gemini 호출
+ChatRequest.builder()
+    .provider("gemini")
+    .model("gemini-2.0-flash")
+    .userPrompt("Hello!")
+    .build();
+```
+
+비즈니스 로직은 프로바이더에 대해 전혀 알 필요가 없다. `ChatRequest`에 담긴 프로바이더와 모델 정보로 `AiService`가 알아서 라우팅한다.
+
+## API 엔드포인트
+
+모델 목록 조회와 채팅 API도 간단하게 노출할 수 있다.
+
+```java
+@RestController
+@RequestMapping("/api/v1/ai")
+@RequiredArgsConstructor
+public class AiController {
+
+    private final AiService aiService;
+
+    @GetMapping("/models")
+    public Map<String, List<String>> getModels() {
+        return aiService.getModels();
+    }
+
+    @PostMapping("/chat")
+    public ChatResponse chat(@RequestBody ChatRequest request) {
+        return aiService.chat(request);
+    }
+}
+```
+
+`/api/v1/ai/models`를 호출하면 사용 가능한 모든 모델 목록을 프로바이더별로 반환한다. 백오피스에서 프롬프트 설정 시 모델을 선택하는 드롭다운에 활용하고 있다.
+
+## 정리
+
+| 프로바이더 | ChatModel 구현체 | 인증 방식 | 특이사항 |
+|------------|------------------|-----------|----------|
+| OpenAI | `OpenAiChatModel` (자동 설정) | API Key | Structured Output(JSON Schema) 지원 |
+| AWS Bedrock | `BedrockProxyChatModel` (수동 빌드) | AWS IAM | Cross-Region Inference 가능 |
+| Google Gemini | `GoogleGenAiChatModel` (자동 설정) | Service Account + OAuth | 토큰 자동 갱신 필요 |
+
+멀티 프로바이더 구성의 핵심은:
+
+1. `chat.client.enabled: false`로 자동 생성을 끄고 직접 Bean 등록
+2. 프로바이더별 `ChatClient`를 `@Qualifier`로 구분
+3. `getAi()` 메서드에서 프로바이더별 옵션을 분기 처리
+4. 모델 ID 기반 자동 프로바이더 감지로 호출 코드 단순화
+
+[다음 편](/posts/spring-ai-guide-03-prompt-structured-output)에서는 프롬프트 관리 전략과 Structured Output으로 LLM 응답을 안정적으로 파싱하는 방법을 다룬다.

--- a/content/posts/spring-ai-guide-03-prompt-structured-output.md
+++ b/content/posts/spring-ai-guide-03-prompt-structured-output.md
@@ -1,0 +1,398 @@
+---
+title: "Spring AI 적용 가이드 (3) - 프롬프트 관리 & Structured Output"
+date: "2026-03-17"
+description: "Spring AI의 메시지 모델, 변수 템플릿링, DB 기반 프롬프트 관리, JSON Schema를 활용한 Structured Output을 다룹니다."
+tags: ["spring-ai", "spring-boot", "ai", "prompt-engineering", "structured-output"]
+series: "Spring AI 적용 가이드"
+seriesOrder: 3
+draft: true
+---
+
+## 프롬프트가 왜 중요한가
+
+LLM을 서비스에 적용할 때, 코드보다 **프롬프트 품질**이 결과를 더 크게 좌우한다. 같은 모델이라도 프롬프트를 어떻게 작성하느냐에 따라 응답 품질이 천차만별이다.
+
+문제는 프롬프트 엔지니어링이 반복적인 실험이 필요한 작업이라는 점이다. 프롬프트를 수정할 때마다 코드를 고치고 배포하는 건 비효율적이다. 그래서 우리는 **프롬프트를 DB에서 관리하고, 배포 없이 실시간으로 변경할 수 있는 구조**를 만들었다.
+
+이번 편에서는 Spring AI의 메시지 모델부터, 프롬프트 관리 시스템과 Structured Output까지 다룬다.
+
+## Spring AI의 메시지 모델
+
+LLM API는 대부분 역할(role) 기반 메시지 구조를 사용한다. Spring AI도 이에 맞춰 `Message` 인터페이스와 구현체를 제공한다.
+
+```mermaid
+classDiagram
+    class Message {
+        <<interface>>
+        +getText() String
+        +getMessageType() MessageType
+    }
+
+    class SystemMessage {
+        LLM의 역할/규칙 지정
+    }
+    class UserMessage {
+        사용자 입력
+    }
+    class AssistantMessage {
+        LLM 응답 few-shot용
+    }
+
+    Message <|-- SystemMessage
+    Message <|-- UserMessage
+    Message <|-- AssistantMessage
+```
+
+```java
+// 메시지 타입별 생성
+new SystemMessage("당신은 영어 교정 전문가입니다.");
+new UserMessage("I went to the libary yesterday.");
+new AssistantMessage("I went to the library yesterday.");  // few-shot 예시
+```
+
+### ChatClient에서 메시지 사용
+
+`ChatClient`의 fluent API로 간단하게 메시지를 구성할 수 있다.
+
+```java
+// 기본 사용법 - system + user
+chatClient.prompt()
+    .system("당신은 영어 교정 전문가입니다.")
+    .user("I went to the libary yesterday.")
+    .call()
+    .content();
+```
+
+여러 메시지를 리스트로 전달할 수도 있다:
+
+```java
+// 멀티 메시지 (few-shot learning 등)
+List<Message> messages = List.of(
+    new SystemMessage("당신은 영어 교정 전문가입니다."),
+    new UserMessage("I went to the libary yesterday."),
+    new AssistantMessage("I went to the library yesterday."),
+    new UserMessage("She don't like it.")
+);
+
+chatClient.prompt()
+    .messages(messages)
+    .call()
+    .content();
+```
+
+## 변수 템플릿링
+
+프롬프트에 동적 데이터를 삽입해야 하는 경우가 많다. 학습자 이름, 수업 내용, 레벨 등을 프롬프트에 넣어야 하는데, 매번 문자열을 직접 조합하면 코드가 지저분해진다.
+
+우리는 `{변수명}` 패턴으로 프롬프트 템플릿을 작성하고, 런타임에 치환하는 방식을 사용한다.
+
+### 프롬프트 템플릿 예시
+
+```
+당신은 {level} 수준의 영어 학습자를 위한 피드백을 생성하는 전문가입니다.
+
+아래 텍스트를 분석하고, {feedback_type}에 대한 피드백을 생성하세요.
+
+텍스트:
+{transcript}
+```
+
+### 변수 치환 구현
+
+```java
+private String renderTemplate(String template, Map<String, Object> variables) {
+    if (!StringUtils.hasText(template) || variables.isEmpty()) {
+        return template;
+    }
+
+    String rendered = template;
+    // 긴 키부터 치환 (부분 매칭 방지)
+    List<String> keys = new ArrayList<>(variables.keySet());
+    keys.sort(Comparator.comparingInt(String::length).reversed());
+
+    for (String key : keys) {
+        Object value = variables.get(key);
+        rendered = rendered.replace(key, stringify(value));
+    }
+    return rendered;
+}
+```
+
+**키를 길이 역순으로 정렬하는 이유**가 있다. `{feedback}`와 `{feedback_type}` 두 변수가 있을 때, `{feedback}`를 먼저 치환하면 `{feedback_type}`의 일부가 잘못 치환될 수 있다. 긴 키부터 처리하면 이 문제를 방지할 수 있다.
+
+### 다양한 변수 포맷 지원
+
+외부에서 넘어오는 변수 키 포맷이 일정하지 않을 수 있다. `{var}`, `{{var}}`, 그냥 `var` 등 다양한 형태를 모두 처리하도록 했다.
+
+```java
+private Map<String, Object> resolveVariables(Map<String, Object> variables) {
+    Map<String, Object> normalized = new LinkedHashMap<>(variables.size());
+    variables.forEach((rawKey, value) -> {
+        String key = rawKey.trim();
+        normalized.put(key, value);
+
+        if (key.startsWith("{") && key.endsWith("}") && key.length() > 2) {
+            String inner = key.substring(1, key.length() - 1);
+            normalized.put(inner, value);
+            normalized.put("{" + inner + "}", value);
+            normalized.put("{{" + inner + "}}", value);
+            return;
+        }
+
+        normalized.put("{" + key + "}", value);
+        normalized.put("{{" + key + "}}", value);
+    });
+    return normalized;
+}
+```
+
+키 하나에 대해 여러 포맷의 변형을 모두 등록해두면, 프롬프트 템플릿에서 어떤 포맷을 쓰든 치환이 동작한다. 프롬프트 작성자가 포맷을 신경 쓰지 않아도 되니 편하다.
+
+### Collection 값 처리
+
+변수 값이 컬렉션(리스트, 셋 등)인 경우 콤마로 연결한다.
+
+```java
+private String stringify(Object value) {
+    if (value == null) return "";
+    if (value instanceof Collection<?> collection) {
+        return collection.stream()
+                .map(this::stringify)
+                .collect(Collectors.joining(","));
+    }
+    return String.valueOf(value);
+}
+```
+
+예를 들어 `tags = ["grammar", "vocabulary", "pronunciation"]`이면 `"grammar,vocabulary,pronunciation"`으로 치환된다.
+
+## DB 기반 프롬프트 관리
+
+프로덕션에서 프롬프트를 코드에 하드코딩하면 수정할 때마다 배포해야 한다. AI 서비스 운영에서 이건 큰 병목이다.
+
+우리는 프롬프트를 DB 테이블에 저장하고, 백오피스에서 관리하는 구조를 만들었다.
+
+### 프롬프트 엔티티
+
+```java
+@Entity
+@Table(name = "le_diagnosis_prompt")
+public class Prompt {
+    @Id
+    private Long id;
+
+    private String type;           // FEEDBACK, QUESTION, STT_CORRECT, STT_CHUNK
+    private String langType;       // KO, EN, JA
+    private String contentLevel;   // BEGINNER, INTERMEDIATE, ADVANCED
+    private String title;          // 프롬프트 식별용 제목
+
+    @Column(columnDefinition = "TEXT")
+    private String systemPrompt;   // 시스템 프롬프트
+
+    @Column(columnDefinition = "TEXT")
+    private String userPrompt;     // 유저 프롬프트 템플릿
+
+    @Column(columnDefinition = "TEXT")
+    private String responseSchema; // JSON Schema (Structured Output용)
+
+    private String modelId;        // 사용할 모델 ID
+    private Integer version;       // 프롬프트 버전
+}
+```
+
+### 프롬프트 조회 및 사용
+
+```java
+// 파이프라인 스텝에서 프롬프트 조회
+Prompt prompt = promptRepository.findByTypeAndLangTypeAndContentLevel(
+    "FEEDBACK", "EN", "INTERMEDIATE"
+);
+
+// 변수 치환 후 AI 호출
+Map<String, Object> variables = Map.of(
+    "transcript", srtText,
+    "level", "intermediate",
+    "feedback_type", "sentence"
+);
+
+ChatRequest request = ChatRequest.builder()
+    .provider(aiService.resolveProviderByModelId(prompt.getModelId()).orElse("openai"))
+    .model(prompt.getModelId())
+    .systemPrompt(prompt.getSystemPrompt())
+    .userPrompt(prompt.getUserPrompt())
+    .variables(variables)
+    .responseSchema(prompt.getResponseSchema())
+    .build();
+
+ChatResponse response = aiService.chat(request);
+```
+
+이 구조의 장점:
+
+- **배포 없이 프롬프트 수정**: 백오피스에서 프롬프트 텍스트를 바꾸면 즉시 반영
+- **버전 관리**: 문제가 생기면 이전 버전으로 롤백
+- **모델 동적 변경**: `modelId` 값만 바꾸면 해당 프롬프트의 모델 교체
+- **A/B 테스트**: 같은 타입의 프롬프트 여러 개를 만들어 성능 비교
+- **다국어/레벨별 분기**: `langType`, `contentLevel`로 조건별 프롬프트 관리
+
+```mermaid
+flowchart LR
+    BO["백오피스"] -->|프롬프트 수정| DB["DB<br/>le_diagnosis_prompt"]
+    DB -->|조회| PS["Pipeline Step"]
+    PS -->|변수 치환| AI["AiService"]
+    AI -->|ChatClient 호출| LLM["LLM"]
+```
+
+## Structured Output
+
+LLM 응답을 코드에서 처리하려면 정해진 형식이어야 한다. "JSON으로 응답해주세요"라고 프롬프트에 넣는 것만으로는 불안정하다. LLM이 마크다운 코드블록으로 감싸거나, 필드를 누락하거나, 형식을 깨뜨리는 경우가 빈번하다.
+
+### JSON Schema 방식
+
+OpenAI는 `response_format`에 JSON Schema를 지정하면, LLM이 해당 스키마를 **반드시** 준수하도록 강제한다. Spring AI에서는 이를 `ResponseFormat`으로 설정한다.
+
+```java
+case "openai" -> {
+    var builder = OpenAiChatOptions.builder().model(model);
+    if (StringUtils.hasText(responseSchema)) {
+        builder.responseFormat(ResponseFormat.builder()
+                .type(ResponseFormat.Type.JSON_SCHEMA)
+                .jsonSchema(responseSchema)
+                .build());
+    }
+    yield openaiChatClient.prompt().options(builder.build());
+}
+```
+
+### JSON Schema 예시
+
+```json
+{
+  "name": "feedback_response",
+  "strict": true,
+  "schema": {
+    "type": "object",
+    "properties": {
+      "feedbacks": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "original": { "type": "string" },
+            "corrected": { "type": "string" },
+            "explanation": { "type": "string" }
+          },
+          "required": ["original", "corrected", "explanation"]
+        }
+      }
+    },
+    "required": ["feedbacks"]
+  }
+}
+```
+
+이 스키마를 DB의 `responseSchema` 필드에 저장하고, `ChatRequest`에 담아서 전달하면 LLM이 이 구조를 따르는 JSON을 반환한다.
+
+### 프로바이더별 지원 현황
+
+Structured Output(JSON Schema)은 프로바이더마다 지원 범위가 다르다.
+
+| 프로바이더 | JSON Schema 지원 | 비고 |
+|------------|------------------|------|
+| OpenAI | O | `response_format.json_schema`로 완벽 지원 |
+| Gemini | △ | `response_mime_type` + 스키마 지원하지만 일부 제약 |
+| Bedrock | X | 프롬프트에 JSON 형식을 직접 지시해야 함 |
+
+OpenAI 외의 프로바이더에서는 JSON Schema가 완벽하게 동작하지 않을 수 있다. JSON repair나 재시도 같은 방어 로직이 함께 필요한데, 이 부분은 [Spring AI 실전 적용기](/posts/spring-ai-pipeline-real-world)에서 다뤘다.
+
+## 메시지 기반 요청
+
+단순한 system + user 구조를 넘어서, 여러 턴의 대화를 배열로 전달해야 할 때가 있다. Few-shot learning이나 대화 이력 기반 호출이 그런 경우다.
+
+### ChatRequest 설계
+
+```java
+public record ChatRequest(
+    String uuid,
+    String provider,
+    String model,
+    String systemPrompt,
+    String userPrompt,
+    Map<String, Object> variables,
+    List<MessageRequest> messages,     // 멀티 턴 메시지
+    String responseSchema
+) {
+    public record MessageRequest(
+        String role,                   // "system", "user", "assistant"
+        String content,
+        Map<String, Object> variables  // 메시지별 변수 오버라이드
+    ) {}
+}
+```
+
+`messages` 필드로 멀티 턴 대화를 지원한다. 각 메시지는 개별적으로 변수를 가질 수 있어서, 메시지마다 다른 데이터를 주입할 수 있다.
+
+### 메시지 빌드
+
+```java
+private List<Message> buildMessages(List<ChatRequest.MessageRequest> messageRequests,
+                                     Map<String, Object> baseVariables) {
+    if (CollectionUtils.isEmpty(messageRequests)) {
+        return List.of();
+    }
+
+    List<Message> messages = new ArrayList<>(messageRequests.size());
+    for (ChatRequest.MessageRequest request : messageRequests) {
+        // 공통 변수에 메시지별 변수를 머지 (오버라이드 가능)
+        Map<String, Object> effectiveVariables = mergeVariables(baseVariables, request.variables());
+        String rendered = renderContent(request.role(), request.content(), effectiveVariables);
+
+        Message message = switch (request.role().trim().toLowerCase()) {
+            case "system" -> new SystemMessage(rendered);
+            case "assistant" -> new AssistantMessage(rendered);
+            case "user" -> new UserMessage(rendered);
+            default -> throw new IllegalArgumentException("지원하지 않는 role: " + request.role());
+        };
+        messages.add(message);
+    }
+    return messages;
+}
+```
+
+`baseVariables`(공통 변수)에 `request.variables()`(메시지별 변수)를 머지해서, 개별 메시지가 공통 변수를 오버라이드할 수 있도록 했다. 같은 프롬프트 템플릿을 쓰되, 메시지마다 약간씩 다른 데이터를 넣어야 할 때 유용하다.
+
+### 프롬프트 적용 우선순위
+
+`ChatRequest`에 `messages`와 `systemPrompt`/`userPrompt`가 동시에 있으면 어떻게 될까? 우선순위를 명확히 정했다:
+
+```java
+private void applyPrompts(ChatClientRequestSpec ai, ChatRequest chatRequest) {
+    Map<String, Object> baseVariables = resolveVariables(chatRequest.variables());
+    List<Message> messages = buildMessages(chatRequest.messages(), baseVariables);
+
+    if (!messages.isEmpty()) {
+        ai.messages(messages);
+        return;  // messages가 있으면 systemPrompt/userPrompt 무시
+    }
+
+    // messages가 없을 때만 systemPrompt/userPrompt 사용
+    if (hasSystem) ai.system(renderSystemPrompt(chatRequest.systemPrompt(), baseVariables));
+    if (hasUser) ai.user(renderPrompt(chatRequest.userPrompt(), baseVariables));
+}
+```
+
+`messages` 배열이 있으면 그걸 사용하고, 없으면 `systemPrompt` + `userPrompt` 조합을 사용한다. 두 방식이 혼재하지 않도록 명확히 분기했다.
+
+## 정리
+
+이번 편에서 다룬 내용을 요약하면:
+
+- **Message 모델**: `SystemMessage`, `UserMessage`, `AssistantMessage`로 역할 기반 대화 구성
+- **변수 템플릿링**: `{var}`, `{{var}}` 등 다양한 포맷을 자동 정규화해서 치환. 길이 역순 정렬로 부분 매칭 방지
+- **DB 프롬프트 관리**: 배포 없이 프롬프트·모델 변경 가능, 버전 관리와 A/B 테스트 지원
+- **Structured Output**: OpenAI JSON Schema로 응답 형식을 강제하되, 프로바이더별 지원 차이에 주의
+- **멀티 턴 메시지**: 메시지별 변수 오버라이드와 명확한 우선순위 분기
+
+프롬프트를 코드가 아닌 데이터로 관리하면, 프롬프트 엔지니어링 사이클이 크게 단축된다. 모델을 바꾸거나 프롬프트를 수정할 때 코드 배포 없이 바로 실험할 수 있다는 건 AI 서비스 운영에서 정말 큰 차이다.
+
+프로덕션 운영에서의 JSON repair, 재시도, 에러 핸들링 등은 [Spring AI 실전 적용기](/posts/spring-ai-pipeline-real-world)에서 자세히 다뤘으니 함께 참고하면 좋다.


### PR DESCRIPTION
## Summary
- Spring AI 적용 가이드 시리즈 블로그 포스트 3편 초안 추가 (draft 상태)
  - 1편: 프로젝트 설정 & 첫 번째 AI 호출
  - 2편: 멀티 프로바이더 전략 (OpenAI, Bedrock, Gemini)
  - 3편: 프롬프트 관리 & Structured Output
- podo-backend 실제 프로덕션 코드 기반 예시

## Test plan
- [ ] `npm run build` 정상 빌드 확인
- [ ] 로컬에서 렌더링 확인
- [ ] 시리즈 네비게이션 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)