### PR TITLE
fix: SPA SEO 문제 해결 - 빌드 시 페이지별 HTML 사전 생성

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@
     <meta property="og:url" content="https://devy1540.github.io" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Devy's Blog" />
+    <meta property="og:image" content="https://devy1540.github.io/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="ko_KR" />
+    <link rel="canonical" href="https://devy1540.github.io" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Devy's Blog" />
+    <meta name="twitter:description" content="개발하며 배운 것들을 정리하고 공유합니다." />
+    <meta name="twitter:image" content="https://devy1540.github.io/og-image.png" />
     <link rel="alternate" type="application/rss+xml" title="Devy's Blog RSS" href="https://devy1540.github.io/rss.xml" />
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
     <!-- Google Analytics (production only) -->

--- a/src/hooks/useMetaTags.ts
+++ b/src/hooks/useMetaTags.ts
@@ -31,6 +31,17 @@ function setNameMeta(name: string, content: string) {
   el.setAttribute("content", content)
 }
 
+function setLink(rel: string, href: string) {
+  let el = document.querySelector(`link[rel="${rel}"][data-meta]`)
+  if (!el) {
+    el = document.createElement("link")
+    el.setAttribute("rel", rel)
+    el.setAttribute("data-meta", "true")
+    document.head.appendChild(el)
+  }
+  el.setAttribute("href", href)
+}
+
 export function useMetaTags({
   title,
   description,
@@ -60,6 +71,12 @@ export function useMetaTags({
     setMeta("og:image", `${BASE_URL}/og-image.png`)
     setMeta("og:image:width", "1200")
     setMeta("og:image:height", "630")
+
+    setLink("canonical", fullUrl)
+    setNameMeta("twitter:card", "summary_large_image")
+    setNameMeta("twitter:title", fullTitle)
+    setNameMeta("twitter:description", desc)
+    setNameMeta("twitter:image", `${BASE_URL}/og-image.png`)
 
     return () => {
       document.title = siteName

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,23 +75,26 @@ function sitemapPlugin(): Plugin {
     name: "generate-sitemap",
     closeBundle() {
       const postsDir = path.resolve(__dirname, "content/posts")
-      const slugs = fs.readdirSync(postsDir)
+      const posts = fs.readdirSync(postsDir)
         .filter((f) => f.endsWith(".md"))
-        .filter((f) => {
+        .map((f) => {
           const raw = fs.readFileSync(path.resolve(postsDir, f), "utf-8")
           const { data } = parseFrontmatter(raw)
-          if (data.draft === "true") return false
-          if (data.publishDate && data.publishDate > new Date().toISOString().split("T")[0]!) return false
-          return true
+          return {
+            slug: f.replace(".md", ""),
+            date: data.date || "",
+            draft: data.draft === "true",
+            publishDate: data.publishDate || "",
+          }
         })
-        .map((f) => f.replace(".md", ""))
+        .filter((p) => !p.draft && !(p.publishDate && p.publishDate > new Date().toISOString().split("T")[0]!))
 
       const staticPages = ["/", "/posts", "/tags", "/series", "/search", "/about"]
       const today = new Date().toISOString().split("T")[0]
 
       const urls = [
         ...staticPages.map((p) => `  <url><loc>${BASE_URL}${p}</loc><lastmod>${today}</lastmod></url>`),
-        ...slugs.map((s) => `  <url><loc>${BASE_URL}/posts/${s}</loc><lastmod>${today}</lastmod></url>`),
+        ...posts.map((p) => `  <url><loc>${BASE_URL}/posts/${p.slug}</loc><lastmod>${p.date || today}</lastmod></url>`),
       ]
 
       const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
@@ -100,6 +103,112 @@ ${urls.join("\n")}
 </urlset>`
 
       fs.writeFileSync(path.resolve(__dirname, "dist/sitemap.xml"), sitemap)
+    },
+  }
+}
+
+function escapeAttr(s: string) {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+function prerenderPlugin(): Plugin {
+  return {
+    name: "prerender-pages",
+    closeBundle() {
+      const distDir = path.resolve(__dirname, "dist")
+      const template = fs.readFileSync(path.resolve(distDir, "index.html"), "utf-8")
+      const postsDir = path.resolve(__dirname, "content/posts")
+
+      function renderPage(opts: {
+        title: string
+        description: string
+        url: string
+        type?: string
+        date?: string
+        outputPath: string
+      }) {
+        const fullTitle = `${opts.title} | Devy's Blog`
+        const desc = opts.description || "개발하며 배운 것들을 정리하고 공유합니다."
+        const fullUrl = `${BASE_URL}${opts.url}`
+        const ogType = opts.type || "website"
+
+        let html = template
+          .replace(/<title>[^<]*<\/title>/, `<title>${escapeAttr(fullTitle)}</title>`)
+          .replace(/(<meta name="description" content=")[^"]*(")/,  `$1${escapeAttr(desc)}$2`)
+          .replace(/(<meta property="og:title" content=")[^"]*(")/,  `$1${escapeAttr(fullTitle)}$2`)
+          .replace(/(<meta property="og:description" content=")[^"]*(")/,  `$1${escapeAttr(desc)}$2`)
+          .replace(/(<meta property="og:url" content=")[^"]*(")/,  `$1${fullUrl}$2`)
+          .replace(/(<meta property="og:type" content=")[^"]*(")/,  `$1${ogType}$2`)
+          .replace(/(<link rel="canonical" href=")[^"]*(")/,  `$1${fullUrl}$2`)
+          .replace(/(<meta name="twitter:title" content=")[^"]*(")/,  `$1${escapeAttr(fullTitle)}$2`)
+          .replace(/(<meta name="twitter:description" content=")[^"]*(")/,  `$1${escapeAttr(desc)}$2`)
+
+        if (opts.type === "article" && opts.date) {
+          const jsonLd = JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            headline: opts.title,
+            description: desc,
+            datePublished: opts.date,
+            url: fullUrl,
+            image: `${BASE_URL}/og-image.png`,
+            author: { "@type": "Person", name: "Devy" },
+            publisher: { "@type": "Organization", name: "Devy's Blog" },
+          })
+          html = html.replace("</head>", `    <script type="application/ld+json">${jsonLd}</script>\n  </head>`)
+        }
+
+        const outPath = path.resolve(distDir, opts.outputPath)
+        fs.mkdirSync(path.dirname(outPath), { recursive: true })
+        fs.writeFileSync(outPath, html)
+      }
+
+      // Pre-render blog posts
+      const posts = fs.readdirSync(postsDir)
+        .filter((f) => f.endsWith(".md"))
+        .map((f) => {
+          const raw = fs.readFileSync(path.resolve(postsDir, f), "utf-8")
+          const { data } = parseFrontmatter(raw)
+          return {
+            slug: f.replace(".md", ""),
+            title: data.title || f.replace(".md", ""),
+            description: data.description || "",
+            date: data.date || "",
+            draft: data.draft === "true",
+            publishDate: data.publishDate || "",
+          }
+        })
+        .filter((p) => !p.draft && !(p.publishDate && p.publishDate > new Date().toISOString().split("T")[0]!))
+
+      for (const post of posts) {
+        renderPage({
+          title: post.title,
+          description: post.description,
+          url: `/posts/${post.slug}`,
+          type: "article",
+          date: post.date,
+          outputPath: `posts/${post.slug}/index.html`,
+        })
+      }
+
+      // Pre-render static pages
+      const staticPages = [
+        { path: "posts", title: "글 목록", description: "개발하며 배운 것들을 정리한 글 목록입니다." },
+        { path: "tags", title: "태그", description: "태그별로 분류된 블로그 글 목록입니다." },
+        { path: "series", title: "시리즈", description: "시리즈별로 분류된 블로그 글 목록입니다." },
+        { path: "about", title: "소개", description: "개발자 Devy의 소개 페이지입니다." },
+      ]
+
+      for (const page of staticPages) {
+        renderPage({
+          title: page.title,
+          description: page.description,
+          url: `/${page.path}`,
+          outputPath: `${page.path}/index.html`,
+        })
+      }
+
+      console.log(`  [prerender] Generated ${posts.length} post pages + ${staticPages.length} static pages`)
     },
   }
 }
@@ -116,7 +225,7 @@ function spa404Plugin(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [react(), sitemapPlugin(), rssPlugin(), spa404Plugin()],
+  plugins: [react(), sitemapPlugin(), rssPlugin(), spa404Plugin(), prerenderPlugin()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- GitHub Pages에서 SPA 라우트가 404 상태코드를 반환하여 검색엔진 크롤러가 블로그 글을 색인하지 못하는 문제 해결
- 빌드 시 `prerenderPlugin`으로 각 포스트/정적 페이지별 `index.html` 생성 → 200 OK 응답으로 정상 색인
- 각 HTML에 고유 title, description, OG tags, canonical URL, Twitter Card, JSON-LD(BlogPosting) 포함
- sitemap `lastmod`를 빌드 날짜 대신 실제 포스트 작성일로 수정
- `useMetaTags` 훅에 canonical URL, Twitter Card 동적 관리 추가

## Test plan
- [x] `npm run build` 성공 (19 post pages + 4 static pages 생성 확인)
- [x] 생성된 HTML에 고유 메타태그, JSON-LD 포함 확인
- [x] sitemap.xml에 포스트별 실제 날짜 반영 확인
- [ ] 배포 후 Google Search Console에서 sitemap 재제출 및 URL 검사

🤖 Generated with [Claude Code](https://claude.com/claude-code)