### PR TITLE
feat: Google Tag Manager 도입

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,16 +24,23 @@
     <meta name="twitter:image" content="https://devy1540.github.io/og-image.png" />
     <link rel="alternate" type="application/rss+xml" title="Devy's Blog RSS" href="https://devy1540.github.io/rss.xml" />
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
-    <!-- Google Analytics (production only) -->
-    <script>
-      if(location.hostname!=='localhost'&&location.hostname!=='127.0.0.1'){var s=document.createElement('script');s.async=true;s.src='https://www.googletagmanager.com/gtag/js?id=G-SW73FSL7LQ';document.head.appendChild(s);window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SW73FSL7LQ');}
-    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-NZLJVG36');</script>
+    <!-- End Google Tag Manager -->
     <script>
       // Prevent theme FOUC
       (function(){var t=localStorage.getItem("theme");if(t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme:dark)").matches))document.documentElement.classList.add("dark");var c=localStorage.getItem("color-theme");if(c)document.documentElement.setAttribute("data-color",c)})();
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NZLJVG36"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- 기존 Google Analytics(gtag.js) 직접 연동을 Google Tag Manager(GTM-NZLJVG36)로 전환
- `<head>`에 GTM 스니펫, `<body>`에 noscript fallback 추가
- 코드 배포 없이 GTM 콘솔에서 태그(GA, 픽셀 등)를 관리할 수 있도록 개선

## Test plan
- [ ] 개발 서버에서 GTM 스니펫이 정상 로드되는지 확인
- [ ] GTM 콘솔에서 GA 태그(G-SW73FSL7LQ) 연결 후 실시간 데이터 수집 확인
- [ ] 기존 `analytics.ts`의 dataLayer 이벤트가 GTM으로 정상 전달되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)