### PR TITLE
fix: sitemap.xml Google 권장 포맷으로 개선

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,18 +89,23 @@ function sitemapPlugin(): Plugin {
         })
         .filter((p) => !p.draft && !(p.publishDate && p.publishDate > new Date().toISOString().split("T")[0]!))
 
-      const staticPages = ["/", "/posts", "/tags", "/series", "/search", "/about"]
+      const staticPages = ["/", "/posts", "/tags", "/series", "/about"]
       const today = new Date().toISOString().split("T")[0]
 
+      function urlEntry(loc: string, lastmod: string) {
+        return `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`
+      }
+
       const urls = [
-        ...staticPages.map((p) => `  <url><loc>${BASE_URL}${p}</loc><lastmod>${today}</lastmod></url>`),
-        ...posts.map((p) => `  <url><loc>${BASE_URL}/posts/${p.slug}</loc><lastmod>${p.date || today}</lastmod></url>`),
+        ...staticPages.map((p) => urlEntry(`${BASE_URL}${p}`, today)),
+        ...posts.map((p) => urlEntry(`${BASE_URL}/posts/${p.slug}`, p.date || today)),
       ]
 
       const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${urls.join("\n")}
-</urlset>`
+</urlset>
+`
 
       fs.writeFileSync(path.resolve(__dirname, "dist/sitemap.xml"), sitemap)
     },


### PR DESCRIPTION
## Summary
- `/search` 페이지를 sitemap에서 제거 (유틸리티 페이지는 Google 색인 불필요)
- XML 엔트리를 Google 공식 문서 멀티라인 형식으로 변경
- `.nojekyll` 파일 추가

## 배포 후 Google Search Console 작업
1. 기존 `/sitemap.xml` 삭제 → 옆 `⋮` → "사이트맵 삭제"
2. URL 검사 도구로 `https://devy1540.github.io/sitemap.xml` 확인 → "실제 URL 테스트"
3. 사이트맵 다시 제출: `sitemap.xml`
4. 주요 페이지 URL 검사에서 "색인 생성 요청"

🤖 Generated with [Claude Code](https://claude.com/claude-code)