### PR TITLE
fix: Google Search Console sitemap 색인 문제 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <meta name="twitter:description" content="개발하며 배운 것들을 정리하고 공유합니다." />
     <meta name="twitter:image" content="https://devy1540.github.io/og-image.png" />
     <link rel="alternate" type="application/rss+xml" title="Devy's Blog RSS" href="https://devy1540.github.io/rss.xml" />
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,8 +47,8 @@ function rssPlugin(): Plugin {
 
       const items = posts.map((p) => `    <item>
       <title>${escapeXml(p.title)}</title>
-      <link>${BASE_URL}/posts/${p.slug}</link>
-      <guid>${BASE_URL}/posts/${p.slug}</guid>
+      <link>${BASE_URL}/posts/${p.slug}/</link>
+      <guid>${BASE_URL}/posts/${p.slug}/</guid>
       <description>${escapeXml(p.description)}</description>
       <pubDate>${p.date ? new Date(p.date).toUTCString() : ""}</pubDate>
     </item>`)
@@ -89,7 +89,7 @@ function sitemapPlugin(): Plugin {
         })
         .filter((p) => !p.draft && !(p.publishDate && p.publishDate > new Date().toISOString().split("T")[0]!))
 
-      const staticPages = ["/", "/posts", "/tags", "/series", "/about"]
+      const staticPages = ["/", "/posts/", "/tags/", "/series/", "/about/"]
       const today = new Date().toISOString().split("T")[0]
 
       function urlEntry(loc: string, lastmod: string) {
@@ -98,7 +98,7 @@ function sitemapPlugin(): Plugin {
 
       const urls = [
         ...staticPages.map((p) => urlEntry(`${BASE_URL}${p}`, today)),
-        ...posts.map((p) => urlEntry(`${BASE_URL}/posts/${p.slug}`, p.date || today)),
+        ...posts.map((p) => urlEntry(`${BASE_URL}/posts/${p.slug}/`, p.date || today)),
       ]
 
       const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
@@ -189,7 +189,7 @@ function prerenderPlugin(): Plugin {
         renderPage({
           title: post.title,
           description: post.description,
-          url: `/posts/${post.slug}`,
+          url: `/posts/${post.slug}/`,
           type: "article",
           date: post.date,
           outputPath: `posts/${post.slug}/index.html`,
@@ -208,7 +208,7 @@ function prerenderPlugin(): Plugin {
         renderPage({
           title: page.title,
           description: page.description,
-          url: `/${page.path}`,
+          url: `/${page.path}/`,
           outputPath: `${page.path}/index.html`,
         })
       }


### PR DESCRIPTION
## Summary
- sitemap.xml, RSS, canonical/OG URL에 trailing slash 추가
- GitHub Pages가 `/posts/slug` → `/posts/slug/`로 301 리다이렉트하여 Google Search Console에서 "Page with redirect"로 색인 거부되던 문제 해결
- 모든 URL이 301 없이 바로 200을 반환하도록 수정

## Test plan
- [ ] `npm run build` 후 `dist/sitemap.xml`의 모든 URL에 trailing slash 확인
- [ ] 배포 후 sitemap URL들이 301 없이 200 반환하는지 확인
- [ ] Google Search Console에서 sitemap 재제출 후 색인 상태 확인