### PR TITLE
fix: FOUC 방지, shadcn Select 적용, 마크다운 링크 viewTransition

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NZLJVG36"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-    <div id="root"></div>
+    <div id="root" style="opacity:0"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,9 @@
   html.dark {
     color-scheme: dark;
   }
+  #root {
+    transition: opacity 150ms ease;
+  }
   body {
     @apply bg-background text-foreground;
     font-family:

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,8 @@ import { LanguageProvider } from "./i18n"
 import { App } from "./App"
 import "./index.css"
 
-createRoot(document.getElementById("root")!).render(
+const root = document.getElementById("root")!
+createRoot(root).render(
   <StrictMode>
     <ThemeProvider>
       <LanguageProvider>
@@ -14,3 +15,5 @@ createRoot(document.getElementById("root")!).render(
     </ThemeProvider>
   </StrictMode>
 )
+// Reveal after React mounts — prevents FOUC from prerendered HTML
+root.style.opacity = "1"

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -141,7 +141,15 @@ export function PostPage() {
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeRaw, rehypeCodeBrFix, rehypeSlug]}
-            components={{ pre: CodeBlock }}
+            components={{
+              pre: CodeBlock,
+              a: ({ href, children, ...props }) => {
+                if (href?.startsWith("/")) {
+                  return <Link to={href} viewTransition {...props}>{children}</Link>
+                }
+                return <a href={href} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
+              },
+            }}
           >
             {post.content}
           </ReactMarkdown>


### PR DESCRIPTION
## Summary
- 프리렌더 HTML의 FOUC 방지 (root opacity:0 → React 마운트 후 fade in)
- BenchmarkChart raw `<select>` → shadcn `Select` 컴포넌트 교체
- 마크다운 본문 내부 링크에 React Router `<Link viewTransition>` 적용

## Test plan
- [ ] 새로고침 시 스타일 없는 텍스트가 먼저 보이지 않는지 확인
- [ ] BenchmarkChart 지표 Select 드롭다운 동작 확인
- [ ] 블로그 글 본문 내 내부 링크 클릭 시 부드러운 전환 확인
- [ ] 외부 링크 클릭 시 새 탭에서 열리는지 확인