### PR TITLE
fix: TXT 포맷 sitemap 추가 (Google XML 파싱 실패 우회)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Allow: /
+
 Sitemap: https://devy1540.github.io/sitemap.xml
+Sitemap: https://devy1540.github.io/sitemap.txt

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -108,6 +108,13 @@ ${urls.join("\n")}
 `
 
       fs.writeFileSync(path.resolve(__dirname, "dist/sitemap.xml"), sitemap)
+
+      // Plain text sitemap (Google-supported fallback format)
+      const txtUrls = [
+        ...staticPages.map((p) => `${BASE_URL}${p}`),
+        ...posts.map((p) => `${BASE_URL}/posts/${p.slug}/`),
+      ]
+      fs.writeFileSync(path.resolve(__dirname, "dist/sitemap.txt"), txtUrls.join("\n") + "\n")
     },
   }
 }


### PR DESCRIPTION
## Summary
- Google Search Console이 sitemap.xml을 계속 읽지 못하는 문제 우회
- Google 공식 지원 포맷인 TXT sitemap (`sitemap.txt`) 생성 추가
- robots.txt에 sitemap.txt 참조 추가

## 배경
sitemap.xml은 기술적으로 완벽하지만(HTTP 200, valid XML, correct content-type, Googlebot UA 정상 응답) Google Search Console이 계속 "사이트맵을 읽을 수 없음" 표시. GitHub Pages CDN(Fastly)과 Google 크롤러 간 호환성 문제로 추정.

## Test plan
- [x] `npm run build` 성공
- [x] `dist/sitemap.txt` 생성 확인 (30개 URL)
- [ ] 배포 후 Google Search Console에서 `sitemap.txt` 제출