### PR TITLE
fix(analytics): 조회수를 GA4 기준으로 단일화

### DIFF
--- a/apps-script/Code.js
+++ b/apps-script/Code.js
@@ -1,9 +1,9 @@
 var PROPERTY_ID = '306384783';
-var SPREADSHEET_ID = '1X-OWsZhJwQcvkDGvMKcTuz2z-OQEF8hi2ac6V0NXMmg';
 var CACHE_TTL = 300; // 5분
+var REPORT_START_DATE = '2020-01-01';
 
 /**
- * GET 요청: summary + daily 합산 단일 응답
+ * GET 요청: GA4 기준 summary + daily 단일 응답
  * CacheService 5분 캐시 적용
  */
 function doGet() {
@@ -16,33 +16,14 @@ function doGet() {
       .setMimeType(ContentService.MimeType.JSON);
   }
 
-  var sheetsData = getSheetsData();
-  var dailyData = getSheetsDailyData();
-  var ga4Daily = getGA4Daily();
-
-  // Sheets daily + GA4 daily 병합 (Sheets 우선)
-  var dailyMap = {};
-  for (var i = 0; i < ga4Daily.length; i++) {
-    dailyMap[ga4Daily[i].date] = ga4Daily[i].views;
-  }
-  for (var i = 0; i < dailyData.length; i++) {
-    var d = dailyData[i].date;
-    dailyMap[d] = (dailyMap[d] || 0) + dailyData[i].views;
-  }
-
-  var daily = [];
-  var dates = Object.keys(dailyMap).sort();
-  for (var i = 0; i < dates.length; i++) {
-    daily.push({ date: dates[i], views: dailyMap[dates[i]] });
-  }
-
+  var summary = getGA4Summary();
   var response = {
-    totalViews: sheetsData.totalViews,
-    pages: sheetsData.pages,
-    daily: daily,
+    totalViews: summary.totalViews,
+    pages: summary.pages,
+    daily: getGA4Daily(),
     meta: {
       cachedAt: new Date().toISOString(),
-      source: 'sheets+ga4'
+      source: 'ga4'
     }
   };
 
@@ -55,173 +36,72 @@ function doGet() {
 }
 
 /**
- * POST 요청: 방문 기록을 Sheets에 실시간 기록
- * sendBeacon으로 호출됨 (text/plain)
+ * POST 요청은 더 이상 조회수 집계에 사용하지 않음.
+ * 조회수의 source of truth는 GA4 Data API.
  */
-function doPost(e) {
+function doPost() {
+  return jsonResponse({
+    success: false,
+    error: 'read-only analytics endpoint'
+  });
+}
+
+function getGA4Summary() {
   try {
-    var body = e.postData ? e.postData.contents : '';
-    var data = JSON.parse(body);
-    var path = normalizePath(data.path || '');
-
-    if (!path || !path.startsWith('/')) {
-      return jsonResponse({ success: false, error: 'invalid path' });
-    }
-
-    // 봇 필터링
-    var ua = (data.userAgent || '').toLowerCase();
-    if (isBot(ua)) {
-      return jsonResponse({ success: false, error: 'bot' });
-    }
-
-    // PageViews 시트에 카운트 증가
-    incrementPageView(path);
-
-    // DailyViews 시트에 오늘 날짜 카운트 증가
-    incrementDailyView();
-
-    // 캐시 무효화
-    CacheService.getScriptCache().remove('pageviews_response');
-
-    return jsonResponse({ success: true });
+    return {
+      totalViews: getGA4TotalViews(),
+      pages: getGA4PageViews()
+    };
   } catch (err) {
-    return jsonResponse({ success: false, error: err.message });
+    Logger.log('getGA4Summary error: ' + err.message);
+    return { totalViews: 0, pages: {} };
   }
 }
 
-// ─── Sheets 데이터 조회 ───
+function getGA4TotalViews() {
+  var request = AnalyticsData.newRunReportRequest();
+  request.dateRanges = [AnalyticsData.newDateRange()];
+  request.dateRanges[0].startDate = REPORT_START_DATE;
+  request.dateRanges[0].endDate = 'today';
+  request.metrics = [AnalyticsData.newMetric()];
+  request.metrics[0].name = 'screenPageViews';
 
-function getSheetsData() {
-  if (!SPREADSHEET_ID) {
-    return { totalViews: 0, pages: {} };
-  }
+  var response = AnalyticsData.Properties.runReport(
+    request, 'properties/' + PROPERTY_ID
+  );
 
-  try {
-    var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
-    var sheet = ss.getSheetByName('PageViews');
-    if (!sheet || sheet.getLastRow() < 2) {
-      return { totalViews: 0, pages: {} };
-    }
+  if (!response.rows || response.rows.length === 0) return 0;
+  return parseInt(response.rows[0].metricValues[0].value, 10) || 0;
+}
 
-    var data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
-    var pages = {};
-    var totalViews = 0;
+function getGA4PageViews() {
+  var request = AnalyticsData.newRunReportRequest();
+  request.dateRanges = [AnalyticsData.newDateRange()];
+  request.dateRanges[0].startDate = REPORT_START_DATE;
+  request.dateRanges[0].endDate = 'today';
+  request.dimensions = [AnalyticsData.newDimension()];
+  request.dimensions[0].name = 'pagePath';
+  request.metrics = [AnalyticsData.newMetric()];
+  request.metrics[0].name = 'screenPageViews';
+  request.limit = 10000;
 
-    for (var i = 0; i < data.length; i++) {
-      var path = String(data[i][0]);
-      var count = Number(data[i][1]) || 0;
+  var response = AnalyticsData.Properties.runReport(
+    request, 'properties/' + PROPERTY_ID
+  );
+
+  var pages = {};
+  if (response.rows) {
+    for (var i = 0; i < response.rows.length; i++) {
+      var path = normalizePath(response.rows[i].dimensionValues[0].value);
+      var views = parseInt(response.rows[i].metricValues[0].value, 10) || 0;
       if (path) {
-        pages[path] = count;
-        totalViews += count;
-      }
-    }
-
-    return { totalViews: totalViews, pages: pages };
-  } catch (err) {
-    Logger.log('getSheetsData error: ' + err.message);
-    return { totalViews: 0, pages: {} };
-  }
-}
-
-function getSheetsDailyData() {
-  if (!SPREADSHEET_ID) return [];
-
-  try {
-    var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
-    var sheet = ss.getSheetByName('DailyViews');
-    if (!sheet || sheet.getLastRow() < 2) return [];
-
-    var data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
-    var daily = [];
-
-    // 최근 30일만 반환
-    var cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - 30);
-    var cutoffStr = formatDate(cutoff);
-
-    for (var i = 0; i < data.length; i++) {
-      var raw = data[i][0];
-      var date = (raw instanceof Date) ? formatDate(raw) : String(raw);
-      var views = Number(data[i][1]) || 0;
-      if (date >= cutoffStr) {
-        daily.push({ date: date, views: views });
-      }
-    }
-
-    return daily;
-  } catch (err) {
-    Logger.log('getSheetsDailyData error: ' + err.message);
-    return [];
-  }
-}
-
-// ─── Sheets 기록 ───
-
-function incrementPageView(path) {
-  if (!SPREADSHEET_ID) return;
-
-  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
-  var sheet = ss.getSheetByName('PageViews');
-  if (!sheet) {
-    sheet = ss.insertSheet('PageViews');
-    sheet.appendRow(['path', 'count', 'lastVisited']);
-  }
-
-  var lastRow = sheet.getLastRow();
-  var found = false;
-
-  if (lastRow >= 2) {
-    var paths = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
-    for (var i = 0; i < paths.length; i++) {
-      if (String(paths[i][0]) === path) {
-        var row = i + 2;
-        var currentCount = Number(sheet.getRange(row, 2).getValue()) || 0;
-        sheet.getRange(row, 2).setValue(currentCount + 1);
-        sheet.getRange(row, 3).setValue(new Date().toISOString());
-        found = true;
-        break;
+        pages[path] = (pages[path] || 0) + views;
       }
     }
   }
 
-  if (!found) {
-    sheet.appendRow([path, 1, new Date().toISOString()]);
-  }
+  return pages;
 }
-
-function incrementDailyView() {
-  if (!SPREADSHEET_ID) return;
-
-  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
-  var sheet = ss.getSheetByName('DailyViews');
-  if (!sheet) {
-    sheet = ss.insertSheet('DailyViews');
-    sheet.appendRow(['date', 'views']);
-  }
-
-  var today = formatDate(new Date());
-  var lastRow = sheet.getLastRow();
-  var found = false;
-
-  if (lastRow >= 2) {
-    var dates = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
-    for (var i = 0; i < dates.length; i++) {
-      if (String(dates[i][0]) === today) {
-        var row = i + 2;
-        var currentCount = Number(sheet.getRange(row, 2).getValue()) || 0;
-        sheet.getRange(row, 2).setValue(currentCount + 1);
-        found = true;
-        break;
-      }
-    }
-  }
-
-  if (!found) {
-    sheet.appendRow([today, 1]);
-  }
-}
-
-// ─── GA4 데이터 (daily용, 상세 분석) ───
 
 function getGA4Daily() {
   try {
@@ -245,7 +125,7 @@ function getGA4Daily() {
     if (response.rows) {
       for (var i = 0; i < response.rows.length; i++) {
         var dateStr = response.rows[i].dimensionValues[0].value;
-        var views = parseInt(response.rows[i].metricValues[0].value);
+        var views = parseInt(response.rows[i].metricValues[0].value, 10) || 0;
         daily.push({
           date: dateStr.substring(0, 4) + '-' + dateStr.substring(4, 6) + '-' + dateStr.substring(6, 8),
           views: views
@@ -259,32 +139,14 @@ function getGA4Daily() {
   }
 }
 
-// ─── 유틸리티 ───
-
 function normalizePath(path) {
   if (!path) return '';
-  // trailing slash 제거 (루트 제외)
+  path = String(path).split('?')[0].split('#')[0];
   if (path.length > 1 && path.endsWith('/')) {
     path = path.slice(0, -1);
   }
-  // 연속 슬래시 제거
   path = path.replace(/\/+/g, '/');
   return path;
-}
-
-function isBot(ua) {
-  var bots = ['bot', 'crawl', 'spider', 'slurp', 'mediapartners', 'prerender', 'lighthouse', 'pagespeed', 'headless'];
-  for (var i = 0; i < bots.length; i++) {
-    if (ua.indexOf(bots[i]) !== -1) return true;
-  }
-  return false;
-}
-
-function formatDate(d) {
-  var yyyy = d.getFullYear();
-  var mm = String(d.getMonth() + 1).padStart(2, '0');
-  var dd = String(d.getDate()).padStart(2, '0');
-  return yyyy + '-' + mm + '-' + dd;
 }
 
 function jsonResponse(obj) {
@@ -293,26 +155,7 @@ function jsonResponse(obj) {
     .setMimeType(ContentService.MimeType.JSON);
 }
 
-// ─── 권한 승인용 (try-catch 없이 직접 호출) ───
-
-function authorizeSheets() {
-  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
-  Logger.log('Sheets authorized: ' + ss.getName());
-}
-
-// ─── 테스트 ───
-
 function testDoGet() {
   var result = doGet();
-  Logger.log(result.getContent());
-}
-
-function testDoPost() {
-  var e = {
-    postData: {
-      contents: JSON.stringify({ path: '/posts/test-post', userAgent: 'Mozilla/5.0' })
-    }
-  };
-  var result = doPost(e);
   Logger.log(result.getContent());
 }

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,15 +1,36 @@
-import { Outlet } from "react-router-dom"
+import { useEffect, useRef } from "react"
+import { Outlet, useLocation } from "react-router-dom"
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar"
 import { AppSidebar } from "@/components/Sidebar"
 import { ScrollToTop } from "@/components/ScrollToTop"
 import { SearchCommand } from "@/components/SearchCommand"
 import { ScrollToTopButton } from "@/components/ScrollToTopButton"
 import { Confetti } from "@/components/Confetti"
+import { trackPageView } from "@/lib/analytics"
+
+function RouteAnalytics() {
+  const location = useLocation()
+  const isInitialPageLoad = useRef(true)
+
+  useEffect(() => {
+    if (isInitialPageLoad.current) {
+      isInitialPageLoad.current = false
+      return
+    }
+
+    const path = `${location.pathname}${location.search}`
+    const timeoutId = window.setTimeout(() => trackPageView(path), 0)
+    return () => window.clearTimeout(timeoutId)
+  }, [location.pathname, location.search])
+
+  return null
+}
 
 export function RootLayout() {
   return (
     <SidebarProvider>
       <ScrollToTop />
+      <RouteAnalytics />
       <Confetti />
       <AppSidebar />
       <SidebarInset>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,36 +1,34 @@
 declare global {
   interface Window {
     gtag?: (...args: unknown[]) => void
+    dataLayer?: Record<string, unknown>[]
   }
 }
 
-function trackEvent(eventName: string, params?: Record<string, string | number>) {
-  window.gtag?.("event", eventName, params)
+type AnalyticsParams = Record<string, string | number | boolean | undefined>
+
+function pushDataLayer(eventName: string, params?: AnalyticsParams) {
+  window.dataLayer = window.dataLayer ?? []
+  window.dataLayer.push({ event: eventName, ...params })
 }
 
-const GA_API_URL = import.meta.env.VITE_GA_API_URL as string | undefined
-
-/**
- * 방문 기록을 Apps Script → Sheets에 실시간 기록
- * sendBeacon 사용으로 페이지 이탈 시에도 안정적
- */
-export function trackPageVisit(path: string) {
-  // dev 모드에서는 비활성화
+function trackEvent(eventName: string, params?: AnalyticsParams) {
   if (import.meta.env.DEV) return
-  if (!GA_API_URL) return
 
-  // 세션 내 중복 방지
-  const key = `visited:${path}`
-  if (sessionStorage.getItem(key)) return
-  sessionStorage.setItem(key, "1")
+  if (window.gtag) {
+    window.gtag("event", eventName, params)
+    return
+  }
 
-  const body = JSON.stringify({
-    path,
-    userAgent: navigator.userAgent,
+  pushDataLayer(eventName, params)
+}
+
+export function trackPageView(path: string) {
+  trackEvent("page_view", {
+    page_path: path,
+    page_location: `${window.location.origin}${path}`,
+    page_title: document.title,
   })
-
-  // sendBeacon은 text/plain으로 전송 (CORS preflight 방지)
-  navigator.sendBeacon(GA_API_URL, body)
 }
 
 export const analytics = {

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -40,7 +40,7 @@ import { SeriesNavigator } from "@/components/SeriesNavigator"
 import { AlertCircle, ArrowLeft, ArrowRight, Clock, Eye } from "lucide-react"
 import { useMetaTags } from "@/hooks/useMetaTags"
 import { usePageViews } from "@/hooks/usePageViews"
-import { analytics, trackPageVisit } from "@/lib/analytics"
+import { analytics } from "@/lib/analytics"
 import { useT } from "@/i18n"
 
 const LazyCodeBlock = lazy(() =>
@@ -107,7 +107,6 @@ export function PostPage() {
   useEffect(() => {
     if (post && slug) {
       analytics.viewPost(post.title, slug)
-      trackPageVisit(`/posts/${slug}`)
     }
   }, [slug]) // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## 목적
조회수와 분석 데이터의 기준을 GA4로 단일화해 Sheets 직접 카운팅과 GA4 데이터가 섞이던 구조를 제거합니다.

## 내용(의도 포함)
- Apps Script의 Sheets 기반 PageViews/DailyViews 읽기/쓰기 로직을 제거하고 GA4 Data API 조회 전용 응답으로 변경했습니다.
- 글 상세 진입 시 Apps Script로 sendBeacon을 보내던 별도 카운팅 경로를 제거했습니다.
- React Router 내부 이동이 GA4 page_view로 잡히도록 라우트 변경 추적을 추가했습니다.
- 실제 운영 반영을 위해서는 이 PR 머지 후 Apps Script 기존 웹앱 배포에 새 버전을 반영해야 합니다.

## 성공기준
- `npm run type-check` 통과
- `npm run lint` 통과 (기존 경고만 존재, 에러 없음)
- `npm run build` 통과
- `git diff --check` 통과
