### PR TITLE
chore(ci): PR 자동 라벨링 추가

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,106 @@
+"target: main":
+  - base-branch: "^main$"
+
+"area: content":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "content/posts/**"
+
+"area: blog":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/pages/HomePage.tsx"
+          - "src/pages/PostPage.tsx"
+          - "src/pages/PostsPage.tsx"
+          - "src/pages/SearchPage.tsx"
+          - "src/pages/SeriesPage.tsx"
+          - "src/pages/TagsPage.tsx"
+          - "src/components/PostList.tsx"
+          - "src/components/SeriesNavigator.tsx"
+          - "src/components/TableOfContents.tsx"
+          - "src/components/CodeBlock.tsx"
+          - "src/components/Comments.tsx"
+          - "src/lib/posts.ts"
+          - "src/lib/reading-time.ts"
+          - "src/types/post.ts"
+
+"area: analytics":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/pages/AnalyticsPage.tsx"
+          - "src/components/DailyVisitsChart.tsx"
+          - "src/lib/analytics.ts"
+          - "src/hooks/usePageViews.ts"
+
+"area: about":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/pages/AboutPage.tsx"
+          - "src/pages/ProjectDetailPage.tsx"
+          - "src/components/ResumePdf.tsx"
+          - "src/components/BenchmarkChart.tsx"
+          - "src/data/resume.ts"
+
+"area: ui":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/components/**"
+          - "src/layouts/**"
+          - "src/index.css"
+          - "src/components/ui/**"
+
+"area: i18n":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/i18n/**"
+
+"area: routing":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/App.tsx"
+          - "src/main.tsx"
+          - "src/app-shell.tsx"
+          - "src/routes.tsx"
+          - "src/routes.server.tsx"
+          - "src/layouts/RootLayout.tsx"
+
+"area: seo":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/hooks/useMetaTags.ts"
+          - "src/entry-server.tsx"
+          - "scripts/prerender.mjs"
+          - "vite.config.ts"
+          - "public/CNAME"
+          - "public/robots.txt"
+          - "public/og-image*"
+          - "public/favicon*"
+
+"area: build":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "package-lock.json"
+          - "tsconfig*.json"
+          - "vite.config.ts"
+          - "eslint.config.*"
+          - "postcss.config.*"
+          - "components.json"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+"dependencies":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "package-lock.json"
+
+"documentation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "README.md"
+          - "AGENTS.md"
+          - "docs/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6


### PR DESCRIPTION
## 목적
main 대상 PR에 변경 영역 라벨을 자동으로 붙여 PR 목록에서 변경 범위를 빠르게 파악할 수 있게 합니다.

## 내용(의도 포함)
- `actions/labeler@v6` 기반 Pull Request Labeler workflow를 추가했습니다.
- 변경 파일 경로 기준으로 `area:*`, `dependencies`, `documentation`, `target: main` 라벨을 매핑했습니다.
- workflow 권한은 라벨 부여에 필요한 `contents: read`, `pull-requests: write`로 제한했습니다.

## 성공기준
- `ruby -e "require 'yaml'; YAML.load_file('.github/labeler.yml'); YAML.load_file('.github/workflows/labeler.yml'); puts 'yaml ok'"`로 YAML 파싱을 확인했습니다.
- `git diff --cached --check`로 스테이징 diff의 whitespace 오류가 없음을 확인했습니다.
- GitHub label 목록에 자동화 설정이 참조하는 custom label들이 생성되어 있음을 확인했습니다.