### PR TITLE
chore(ci): 릴리즈 PR 자동 병합 개선

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,12 +15,16 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: node
+          token: ${{ secrets.PAT_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
-      - name: Auto-merge Release PR
-        if: steps.release.outputs.pr
-        run: gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --merge
+      - name: Enable auto-merge Release PR
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          pr_number="$(jq -r '.number' <<< "$RELEASE_PR")"
+          gh pr merge "$pr_number" --auto --squash --delete-branch
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           GH_REPO: ${{ github.repository }}
-
+          RELEASE_PR: ${{ steps.release.outputs.pr }}


### PR DESCRIPTION
## 목적
릴리즈 PR을 즉시 병합하지 않고 GitHub Auto-merge에 맡겨 branch rule과 required check를 통과한 뒤 병합되도록 개선합니다.

## 내용(의도 포함)
- release-please action이 `PAT_TOKEN`, `release-please-config.json`, `.release-please-manifest.json`을 명시적으로 사용하도록 변경했습니다.
- release PR 병합 방식을 즉시 `--merge`에서 `--auto --squash --delete-branch`로 변경했습니다.
- release PR 번호는 release-please output JSON을 `jq`로 파싱해 전달하도록 정리했습니다.
- GitHub repo 설정에서 `allow_auto_merge`를 활성화했습니다.

## 성공기준
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-please.yml'); puts 'yaml ok'"`로 workflow YAML 파싱을 확인했습니다.
- `git diff --check`와 `git diff --cached --check`로 whitespace 오류가 없음을 확인했습니다.
- GitHub repo 설정에서 `allow_auto_merge: true`를 확인했습니다.