### PR TITLE
chore: 사이트 브랜드 문구 갱신

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="naver-site-verification" content="285723bcf1d1a6cbcc547cce5f249758f4c43267" />
     <meta name="google-site-verification" content="DHPJy4dX7hesl1Kl-WWs7e4l4P211suOLbmlkT-pAUE" />
-    <title>Devy's Blog</title>
-    <meta name="description" content="Devy가 배우고 경험한 것들을 정리하는 블로그입니다." />
+    <title>Devy Archive</title>
+    <meta name="description" content="Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다." />
     <meta property="og:title" content="Devy Archive" />
-    <meta property="og:description" content="Devy가 배우고 경험한 것들을 정리하는 블로그입니다." />
+    <meta property="og:description" content="Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다." />
     <meta property="og:url" content="https://devy1540.dev" />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Devy's Blog" />
+    <meta property="og:site_name" content="Devy Archive" />
     <meta property="og:image" content="https://devy1540.dev/og-image.png?v=20260610" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -21,10 +21,10 @@
     <link rel="canonical" href="https://devy1540.dev" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Devy Archive" />
-    <meta name="twitter:description" content="Devy가 배우고 경험한 것들을 정리하는 블로그입니다." />
+    <meta name="twitter:description" content="Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다." />
     <meta name="twitter:image" content="https://devy1540.dev/og-image.png?v=20260610" />
     <meta name="twitter:image:alt" content="Devy Archive preview image" />
-    <link rel="alternate" type="application/rss+xml" title="Devy's Blog RSS" href="https://devy1540.dev/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title="Devy Archive RSS" href="https://devy1540.dev/rss.xml" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="https://devy1540.dev/sitemap-gsc.xml" />
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
     <!-- Google Tag Manager -->

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -18,7 +18,7 @@ function escapeAttr(value) {
 }
 
 function toFullTitle(title) {
-  return title ? `${title} | Devy's Blog` : "Devy's Blog"
+  return title ? `${title} | Devy Archive` : "Devy Archive"
 }
 
 function safeJsonLd(jsonLd) {
@@ -32,7 +32,7 @@ function outputPathFor(routePath) {
 
 function withHead(templateHtml, route) {
   const fullTitle = toFullTitle(route.title)
-  const description = route.description || "Devy가 배우고 경험한 것들을 정리하는 블로그입니다."
+  const description = route.description || "Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다."
   const previewTitle = route.ogTitle || fullTitle
   const previewDescription = route.ogDescription || description
   const fullUrl = `${baseUrl}${route.path}`

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -46,7 +46,7 @@ function toCanonicalPath(path: string) {
 
 export function getPrerenderRoutes(): PrerenderRoute[] {
   const posts = getAllPosts()
-  const homeDescription = "Devy가 배우고 경험한 것들을 정리하는 블로그입니다."
+  const homeDescription = "Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다."
 
   return [
     {
@@ -57,7 +57,7 @@ export function getPrerenderRoutes(): PrerenderRoute[] {
       jsonLd: {
         "@context": "https://schema.org",
         "@type": "Blog",
-        name: "Devy's Blog",
+        name: "Devy Archive",
         description: homeDescription,
         url: BASE_URL,
         inLanguage: "ko-KR",
@@ -137,7 +137,7 @@ export function getPrerenderRoutes(): PrerenderRoute[] {
           url: `${BASE_URL}/posts/${post.slug}/`,
           image: OG_IMAGE_URL,
           author: { "@type": "Person", name: "Devy" },
-          publisher: { "@type": "Organization", name: "Devy's Blog" },
+          publisher: { "@type": "Organization", name: "Devy Archive" },
           mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/posts/${post.slug}/` },
           articleBody,
           ...(post.tags.length > 0 ? { keywords: post.tags.join(", ") } : {}),

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -145,7 +145,7 @@ export const ko: Translations = {
     viewAll: "전체 보기",
   },
   home: {
-    subtitle: "Java, Spring, Kubernetes, observability, React와 운영 경험을 정리합니다.",
+    subtitle: "백엔드 개발과 플랫폼 운영에서 마주한 문제, 선택, 해결 과정을 기록합니다.",
     viewPosts: "글 목록 보기",
     introduction: "소개",
     popularPosts: "인기 글",
@@ -256,9 +256,9 @@ export const ko: Translations = {
     general: "일반",
   },
   meta: {
-    siteName: "Devy's Blog",
+    siteName: "Devy Archive",
     homeTitle: "백엔드·인프라 개발 기록",
-    defaultDescription: "Devy가 배우고 경험한 것들을 정리하는 블로그입니다.",
+    defaultDescription: "Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다.",
   },
 }
 
@@ -276,7 +276,7 @@ export const en: Translations = {
     viewAll: "View All",
   },
   home: {
-    subtitle: "Documenting and sharing what I learn through development.",
+    subtitle: "Notes on backend engineering, platform operations, and the decisions behind them.",
     viewPosts: "View Posts",
     introduction: "About",
     popularPosts: "Popular Posts",
@@ -387,8 +387,8 @@ export const en: Translations = {
     general: "General",
   },
   meta: {
-    siteName: "Devy's Blog",
+    siteName: "Devy Archive",
     homeTitle: "Backend and Infrastructure Engineering Notes",
-    defaultDescription: "Notes from what Devy learns and experiences.",
+    defaultDescription: "An archive of Devy's development and operations notes, organized around problem solving.",
   },
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -13,7 +13,7 @@ export function HomePage() {
   useMetaTags({
     title: t.meta.homeTitle,
     description: t.meta.defaultDescription,
-    ogTitle: "Devy Archive",
+    ogTitle: t.meta.siteName,
     url: "/",
   })
   const posts = getAllPosts()
@@ -42,7 +42,7 @@ export function HomePage() {
       {/* Hero */}
       <section className="mb-10 animate-in fade-in slide-in-from-bottom-4 duration-500 fill-mode-backwards">
         <h1 className="text-4xl font-bold tracking-tight mb-2">
-          Devy's Blog
+          {t.meta.siteName}
         </h1>
         <p className="text-muted-foreground">
           {t.home.subtitle}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,9 +56,9 @@ function rssPlugin(): Plugin {
       const rss = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Devy's Blog</title>
+    <title>Devy Archive</title>
     <link>${BASE_URL}</link>
-    <description>개발하며 배운 것들을 정리하고 공유합니다.</description>
+    <description>Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다.</description>
     <language>ko</language>
     <atom:link href="${BASE_URL}/rss.xml" rel="self" type="application/rss+xml"/>
 ${items.join("\n")}


### PR DESCRIPTION
## 목적

사이트 홈과 메타데이터에 노출되는 브랜드명을 Devy Archive로 통일합니다.
홈 소개 문구를 기술 나열보다 기록의 성격이 드러나는 표현으로 조정합니다.

## 내용(의도 포함)

- 홈 H1을 번역 메타의 사이트명 기반으로 렌더링하도록 변경했습니다.
- 한국어/영어 번역, 기본 HTML, SSG/JSON-LD, RSS 메타의 사이트명과 설명을 갱신했습니다.
- 런타임 표면이 아닌 프로젝트 문서와 과거 글 예시의 Devy's Blog 표기는 이번 범위에서 제외했습니다.

## 성공기준

- `npm run type-check` 통과
- 홈 화면 H1이 Devy Archive로 표시되는 변경이 포함됨
- 홈 소개 문구가 백엔드 개발과 플랫폼 운영의 문제 해결 기록을 설명하도록 변경됨