### PR TITLE
feat(adsense): 애드센스 검증 코드 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="naver-site-verification" content="285723bcf1d1a6cbcc547cce5f249758f4c43267" />
     <meta name="google-site-verification" content="DHPJy4dX7hesl1Kl-WWs7e4l4P211suOLbmlkT-pAUE" />
+    <meta name="google-adsense-account" content="ca-pub-2383130502932429" />
     <title>Devy Archive</title>
     <meta name="description" content="Devy의 개발과 운영 기록을 문제 해결 중심으로 모아둔 아카이브입니다." />
     <meta property="og:title" content="Devy Archive" />
@@ -27,6 +28,8 @@
     <link rel="alternate" type="application/rss+xml" title="Devy Archive RSS" href="https://devy1540.dev/rss.xml" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="https://devy1540.dev/sitemap-gsc.xml" />
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2383130502932429"
+      crossorigin="anonymous"></script>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2383130502932429, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 목적
AdSense 사이트 소유권 확인과 ads.txt 검증을 위해 필요한 코드를 추가합니다.

## 내용(의도 포함)
- index.html head에 google-adsense-account meta 태그를 추가했습니다.
- index.html head에 AdSense 스크립트를 추가했습니다.
- public/ads.txt에 Google AdSense 판매자 정보를 추가했습니다.

## 성공기준
- npm run build가 성공해야 합니다.
- 빌드 결과의 dist/index.html에 AdSense meta/script가 포함되어야 합니다.
- 빌드 결과의 dist/ads.txt에 Google AdSense 판매자 정보가 포함되어야 합니다.