### PR TITLE
feat(blog): 글 목록과 태그 탐색 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ flowchart LR
 | `/` | Home | 최신글, 인기글, 블로그 통계 |
 | `/posts` | Posts | 전체 글 목록, 검색, 정렬, 태그/연도 필터 |
 | `/posts/:slug` | Post | Markdown 글 상세, TOC, 댓글 |
-| `/tags` | Tags | 태그별 글 탐색 |
+| `/tags` | Tags | 태그별 주제 탐색, 관련 태그, 최근 글 |
 | `/series` | Series | 시리즈별 글 탐색 |
 | `/analytics` | Analytics | 방문자 및 조회수 대시보드 |
 | `/about` | About | 소개, 경력, 프로젝트 요약 |

--- a/README.md
+++ b/README.md
@@ -90,11 +90,10 @@ flowchart LR
 | Path | Page | Description |
 | --- | --- | --- |
 | `/` | Home | 최신글, 인기글, 블로그 통계 |
-| `/posts` | Posts | 전체 글 목록, 리스트/그리드 뷰 |
+| `/posts` | Posts | 전체 글 목록, 검색, 정렬, 태그/연도 필터 |
 | `/posts/:slug` | Post | Markdown 글 상세, TOC, 댓글 |
 | `/tags` | Tags | 태그별 글 탐색 |
 | `/series` | Series | 시리즈별 글 탐색 |
-| `/search` | Search | 키워드, 날짜, 태그 기반 고급 검색 |
 | `/analytics` | Analytics | 방문자 및 조회수 대시보드 |
 | `/about` | About | 소개, 경력, 프로젝트 요약 |
 | `/about/projects/:slug` | Project Detail | 프로젝트 상세 |

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useLocation, useNavigate } from "react-router-dom"
-import { Home, FileText, Tags, User, Search, Library, BarChart3 } from "lucide-react"
+import { Home, FileText, Tags, User, Library, BarChart3 } from "lucide-react"
 import {
   Sidebar as SidebarRoot,
   SidebarContent,
@@ -25,7 +25,6 @@ const navIcons = {
   home: Home,
   posts: FileText,
   series: Library,
-  search: Search,
   tags: Tags,
   analytics: BarChart3,
   about: User,
@@ -50,7 +49,6 @@ export function AppSidebar() {
     { label: t.common.home, to: localizePath("/", language), basePath: "/", icon: navIcons.home },
     { label: t.common.posts, to: localizePath("/posts", language), basePath: "/posts", icon: navIcons.posts },
     { label: t.common.series, to: localizePath("/series", language), basePath: "/series", icon: navIcons.series },
-    { label: t.common.search, to: localizePath("/search", language), basePath: "/search", icon: navIcons.search },
     { label: t.common.tags, to: localizePath("/tags", language), basePath: "/tags", icon: navIcons.tags },
     { label: t.common.analytics, to: localizePath("/analytics", language), basePath: "/analytics", icon: navIcons.analytics },
     { label: t.common.about, to: localizePath("/about", language), basePath: "/about", icon: navIcons.about },

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -136,11 +136,13 @@ function localizedStaticRoutes(language: Language, posts: PostMeta[]): Prerender
     {
       path: path("/search/"),
       language,
-      title: isEnglish ? "Search" : "검색",
-      description: isEnglish ? "Search blog posts by keyword, tag, or date." : "블로그 글을 키워드, 태그, 날짜로 검색합니다.",
+      title: isEnglish ? "Posts" : "글 목록",
+      description: postsDescription,
+      noindex: true,
+      canonicalPath: path("/posts/"),
       alternates: {
-        ko: "/search/",
-        en: "/en/search/",
+        ko: "/posts/",
+        en: "/en/posts/",
       },
     },
     {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -84,6 +84,23 @@ export interface Translations {
   }
   tags: {
     description: string
+    summary: (postCount: number, tagCount: number) => string
+    searchPlaceholder: string
+    sortPopular: string
+    sortRecent: string
+    sortName: string
+    reset: string
+    selectedLabel: (tag: string) => string
+    topTags: string
+    topTagsNote: string
+    topicGroups: string
+    ungrouped: string
+    postCount: (count: number) => string
+    relatedTags: string
+    recentPosts: string
+    selectedDescription: (tag: string) => string
+    viewInPosts: (tag: string) => string
+    noMatchingTags: string
     noTags: string
     allTags: string
     noPostsWithTag: string
@@ -243,6 +260,23 @@ export const ko: Translations = {
   },
   tags: {
     description: "태그별 블로그 글 목록",
+    summary: (postCount, tagCount) => `${postCount}개의 글이 ${tagCount}개의 태그로 정리되어 있습니다.`,
+    searchPlaceholder: "태그 이름 검색",
+    sortPopular: "많은 글순",
+    sortRecent: "최근 글순",
+    sortName: "가나다순",
+    reset: "초기화",
+    selectedLabel: (tag) => `선택됨 · ${tag}`,
+    topTags: "주요 태그",
+    topTagsNote: "글 수와 최근 발행 기준",
+    topicGroups: "주제 그룹",
+    ungrouped: "기타",
+    postCount: (count) => `${count}개 글`,
+    relatedTags: "관련 태그",
+    recentPosts: "최근 글",
+    selectedDescription: (tag) => `${tag} 태그가 붙은 글의 흐름과 함께 자주 등장하는 주제를 모아봅니다.`,
+    viewInPosts: (tag) => `${tag} 글 목록으로 보기`,
+    noMatchingTags: "조건에 맞는 태그가 없습니다.",
     noTags: "태그가 없습니다.",
     allTags: "전체 태그",
     noPostsWithTag: "해당 태그의 글이 없습니다.",
@@ -402,6 +436,23 @@ export const en: Translations = {
   },
   tags: {
     description: "Blog posts by tag",
+    summary: (postCount, tagCount) => `${postCount} post${postCount !== 1 ? "s" : ""} are organized with ${tagCount} tag${tagCount !== 1 ? "s" : ""}.`,
+    searchPlaceholder: "Search tags",
+    sortPopular: "Most used",
+    sortRecent: "Recent",
+    sortName: "A-Z",
+    reset: "Reset",
+    selectedLabel: (tag) => `Selected · ${tag}`,
+    topTags: "Top Tags",
+    topTagsNote: "By post count and latest publish date",
+    topicGroups: "Topic Groups",
+    ungrouped: "Other",
+    postCount: (count) => `${count} post${count !== 1 ? "s" : ""}`,
+    relatedTags: "Related Tags",
+    recentPosts: "Recent Posts",
+    selectedDescription: (tag) => `Explore posts tagged with ${tag} and the topics that often appear with it.`,
+    viewInPosts: (tag) => `View ${tag} posts`,
+    noMatchingTags: "No tags match these filters.",
     noTags: "No tags yet.",
     allTags: "All tags",
     noPostsWithTag: "No posts with this tag.",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -44,6 +44,22 @@ export interface Translations {
     description: string
     listView: string
     gridView: string
+    searchPlaceholder: string
+    sortLabel: string
+    yearLabel: string
+    scopeLabel: string
+    sortLatest: string
+    sortPopular: string
+    sortOldest: string
+    allYears: string
+    allTags: string
+    scopeAll: string
+    scopeSummary: string
+    scopeTags: string
+    reset: string
+    totalCount: (count: number) => string
+    filteredCount: (count: number) => string
+    noResults: string
   }
   search: {
     description: string
@@ -55,6 +71,9 @@ export interface Translations {
     reset: string
     noResults: string
     searchGuide: string
+    redirectTitle: string
+    redirectDescription: string
+    goToPosts: string
   }
   series: {
     description: string
@@ -184,6 +203,22 @@ export const ko: Translations = {
     description: "전체 블로그 글 목록",
     listView: "리스트 보기",
     gridView: "그리드 보기",
+    searchPlaceholder: "제목, 설명, 태그, 본문 검색",
+    sortLabel: "정렬",
+    yearLabel: "연도",
+    scopeLabel: "검색 범위",
+    sortLatest: "최신순",
+    sortPopular: "인기순",
+    sortOldest: "오래된순",
+    allYears: "전체 연도",
+    allTags: "전체",
+    scopeAll: "제목, 설명, 태그, 본문",
+    scopeSummary: "제목, 설명, 태그",
+    scopeTags: "태그만",
+    reset: "초기화",
+    totalCount: (count) => `${count}개의 글을 최신순으로 보고 있습니다.`,
+    filteredCount: (count) => `${count}개의 글을 찾았습니다.`,
+    noResults: "조건에 맞는 글이 없습니다.",
   },
   search: {
     description: "블로그 글 검색",
@@ -195,6 +230,9 @@ export const ko: Translations = {
     reset: "초기화",
     noResults: "검색 결과가 없습니다.",
     searchGuide: "키워드, 날짜, 태그를 선택하여 검색하세요.",
+    redirectTitle: "검색이 글 목록으로 통합되었습니다",
+    redirectDescription: "글 검색과 필터는 이제 글 목록에서 함께 사용할 수 있습니다.",
+    goToPosts: "글 목록으로 이동",
   },
   series: {
     description: "시리즈별 블로그 글 목록",
@@ -324,6 +362,22 @@ export const en: Translations = {
     description: "All blog posts",
     listView: "List view",
     gridView: "Grid view",
+    searchPlaceholder: "Search title, description, tags, or content",
+    sortLabel: "Sort",
+    yearLabel: "Year",
+    scopeLabel: "Search scope",
+    sortLatest: "Latest",
+    sortPopular: "Popular",
+    sortOldest: "Oldest",
+    allYears: "All years",
+    allTags: "All",
+    scopeAll: "Title, description, tags, content",
+    scopeSummary: "Title, description, tags",
+    scopeTags: "Tags only",
+    reset: "Reset",
+    totalCount: (count) => `Showing ${count} post${count !== 1 ? "s" : ""} by latest date.`,
+    filteredCount: (count) => `Found ${count} post${count !== 1 ? "s" : ""}.`,
+    noResults: "No posts match these filters.",
   },
   search: {
     description: "Search blog posts",
@@ -335,6 +389,9 @@ export const en: Translations = {
     reset: "Reset",
     noResults: "No results found.",
     searchGuide: "Search by keyword, date, or tag.",
+    redirectTitle: "Search moved to Posts",
+    redirectDescription: "Post search and filters are now available directly in the posts list.",
+    goToPosts: "Go to posts",
   },
   series: {
     description: "Blog posts by series",

--- a/src/pages/PostsPage.tsx
+++ b/src/pages/PostsPage.tsx
@@ -1,23 +1,135 @@
-import { useState, useMemo } from "react"
+import { useMemo, useState } from "react"
+import { useSearchParams } from "react-router-dom"
 import { useMetaTags } from "@/hooks/useMetaTags"
-import { LayoutListIcon, LayoutGridIcon } from "lucide-react"
-import { getAllPosts } from "@/lib/posts"
+import { LayoutListIcon, LayoutGridIcon, SearchIcon, XIcon } from "lucide-react"
+import { getAllPosts, searchPosts } from "@/lib/posts"
 import { PostList } from "@/components/PostList"
 import { PageContainer } from "@/components/PageContainer"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { usePageViews } from "@/hooks/usePageViews"
 import { useLanguage } from "@/i18n"
 import { localizePath } from "@/lib/i18n-routing"
 import type { PostMeta } from "@/types/post"
 
+type SortMode = "latest" | "popular" | "oldest"
+type SearchScope = "all" | "summary" | "tags"
+
+const sortModes = new Set<SortMode>(["latest", "popular", "oldest"])
+const searchScopes = new Set<SearchScope>(["all", "summary", "tags"])
+
+function toSortMode(value: string | null): SortMode {
+  return sortModes.has(value as SortMode) ? (value as SortMode) : "latest"
+}
+
+function toSearchScope(value: string | null): SearchScope {
+  return searchScopes.has(value as SearchScope) ? (value as SearchScope) : "all"
+}
+
+function postMatchesSummary(post: PostMeta, query: string) {
+  const q = query.toLowerCase()
+  return (
+    post.title.toLowerCase().includes(q) ||
+    post.description.toLowerCase().includes(q) ||
+    post.tags.some((tag) => tag.toLowerCase().includes(q))
+  )
+}
+
+function postMatchesTags(post: PostMeta, query: string) {
+  const q = query.toLowerCase()
+  return post.tags.some((tag) => tag.toLowerCase().includes(q))
+}
+
 export function PostsPage() {
   const { language, t } = useLanguage()
   useMetaTags({ title: t.common.posts, description: t.posts.description, url: localizePath("/posts", language) })
-  const posts = getAllPosts(language)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { getPostViews } = usePageViews()
+  const allPosts = useMemo(() => getAllPosts(language), [language])
   const [viewMode, setViewMode] = useState<"list" | "grid">("list")
+
+  const query = searchParams.get("q") ?? ""
+  const selectedTag = searchParams.get("tag") ?? ""
+  const selectedYear = searchParams.get("year") ?? ""
+  const sortMode = toSortMode(searchParams.get("sort"))
+  const searchScope = toSearchScope(searchParams.get("scope"))
+
+  function updateParam(key: string, value: string, defaultValue = "") {
+    const next = new URLSearchParams(searchParams)
+    if (!value || value === defaultValue) {
+      next.delete(key)
+    } else {
+      next.set(key, value)
+    }
+    setSearchParams(next, { replace: true })
+  }
+
+  function resetFilters() {
+    setSearchParams({}, { replace: true })
+  }
+
+  const availableYears = useMemo(() => (
+    Array.from(new Set(allPosts.map((post) => post.date.slice(0, 4)))).sort((a, b) => (a > b ? -1 : 1))
+  ), [allPosts])
+
+  const featuredTags = useMemo(() => {
+    const tagCounts = new Map<string, number>()
+    for (const post of allPosts) {
+      for (const tag of post.tags) {
+        tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1)
+      }
+    }
+
+    const tags = [...tagCounts.entries()]
+      .sort(([a, aCount], [b, bCount]) => bCount - aCount || a.localeCompare(b))
+      .slice(0, 7)
+      .map(([tag]) => tag)
+
+    if (selectedTag && !tags.includes(selectedTag)) return [selectedTag, ...tags]
+    return tags
+  }, [allPosts, selectedTag])
+
+  const filteredPosts = useMemo(() => {
+    const trimmedQuery = query.trim()
+    let result = trimmedQuery
+      ? searchScope === "all"
+        ? searchPosts(trimmedQuery, language)
+        : allPosts.filter((post) => (
+          searchScope === "summary"
+            ? postMatchesSummary(post, trimmedQuery)
+            : postMatchesTags(post, trimmedQuery)
+        ))
+      : allPosts
+
+    if (selectedTag) {
+      result = result.filter((post) => post.tags.includes(selectedTag))
+    }
+    if (selectedYear) {
+      result = result.filter((post) => post.date.startsWith(selectedYear))
+    }
+
+    return [...result].sort((a, b) => {
+      if (sortMode === "oldest") return a.date > b.date ? 1 : -1
+      if (sortMode === "popular") {
+        const aViews = getPostViews(a.slug, a.language) ?? -1
+        const bViews = getPostViews(b.slug, b.language) ?? -1
+        if (aViews !== bViews) return bViews - aViews
+      }
+      return a.date > b.date ? -1 : 1
+    })
+  }, [allPosts, getPostViews, language, query, searchScope, selectedTag, selectedYear, sortMode])
 
   const groupedByYear = useMemo(() => {
     const groups = new Map<string, PostMeta[]>()
-    for (const post of posts) {
+    for (const post of filteredPosts) {
       const year = post.date.slice(0, 4)
       const list = groups.get(year)
       if (list) {
@@ -27,7 +139,9 @@ export function PostsPage() {
       }
     }
     return groups
-  }, [posts])
+  }, [filteredPosts])
+
+  const hasFilters = Boolean(query.trim() || selectedTag || selectedYear || sortMode !== "latest" || searchScope !== "all")
 
   return (
     <PageContainer>
@@ -48,14 +162,112 @@ export function PostsPage() {
         </ToggleGroup>
       </div>
 
-      {[...groupedByYear.entries()].map(([year, yearPosts]) => (
-        <div key={year} className="mb-8">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
-            {year}
-          </h2>
-          <PostList posts={yearPosts} viewMode={viewMode} />
+      <div className="mb-8 space-y-3">
+        <div className="relative">
+          <SearchIcon className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => updateParam("q", event.target.value)}
+            placeholder={t.posts.searchPlaceholder}
+            className="pl-9"
+          />
         </div>
-      ))}
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap gap-2">
+            <Select
+              value={sortMode}
+              onValueChange={(value) => updateParam("sort", value, "latest")}
+            >
+              <SelectTrigger aria-label={t.posts.sortLabel} className="w-[6.5rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="latest">{t.posts.sortLatest}</SelectItem>
+                <SelectItem value="popular">{t.posts.sortPopular}</SelectItem>
+                <SelectItem value="oldest">{t.posts.sortOldest}</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={selectedYear || "all"}
+              onValueChange={(value) => updateParam("year", value === "all" ? "" : value)}
+            >
+              <SelectTrigger aria-label={t.posts.yearLabel} className="w-[7.5rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t.posts.allYears}</SelectItem>
+                {availableYears.map((year) => (
+                  <SelectItem key={year} value={year}>{year}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={searchScope}
+              onValueChange={(value) => updateParam("scope", value, "all")}
+            >
+              <SelectTrigger aria-label={t.posts.scopeLabel} className="w-[12.5rem] max-w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t.posts.scopeAll}</SelectItem>
+                <SelectItem value="summary">{t.posts.scopeSummary}</SelectItem>
+                <SelectItem value="tags">{t.posts.scopeTags}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {hasFilters && (
+            <Button type="button" variant="ghost" size="sm" onClick={resetFilters}>
+              <XIcon className="size-3" />
+              {t.posts.reset}
+            </Button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          <Button
+            type="button"
+            variant={selectedTag ? "outline" : "default"}
+            size="xs"
+            className="rounded-full"
+            onClick={() => updateParam("tag", "")}
+          >
+            {t.posts.allTags}
+          </Button>
+          {featuredTags.map((tag) => (
+            <Button
+              key={tag}
+              type="button"
+              variant={selectedTag === tag ? "default" : "outline"}
+              size="xs"
+              className="rounded-full"
+              onClick={() => updateParam("tag", selectedTag === tag ? "" : tag)}
+            >
+              {tag}
+            </Button>
+          ))}
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          {hasFilters ? t.posts.filteredCount(filteredPosts.length) : t.posts.totalCount(allPosts.length)}
+        </p>
+      </div>
+
+      {filteredPosts.length === 0 ? (
+        <PostList posts={filteredPosts} emptyMessage={t.posts.noResults} />
+      ) : (
+        [...groupedByYear.entries()].map(([year, yearPosts]) => (
+          <div key={year} className="mb-8">
+            <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              {year}
+            </h2>
+            <PostList posts={yearPosts} viewMode={viewMode} />
+          </div>
+        ))
+      )}
     </PageContainer>
   )
 }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,99 +1,38 @@
-import { useState } from "react"
-import { SearchIcon, XIcon } from "lucide-react"
-import { advancedSearch, getAllTags } from "@/lib/posts"
-import { PostList } from "@/components/PostList"
+import { useEffect } from "react"
+import { Link, useLocation, useNavigate } from "react-router-dom"
 import { PageContainer } from "@/components/PageContainer"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
-import { DatePicker } from "@/components/DatePicker"
 import { useMetaTags } from "@/hooks/useMetaTags"
 import { useLanguage } from "@/i18n"
 import { localizePath } from "@/lib/i18n-routing"
 
 export function SearchPage() {
   const { language, t } = useLanguage()
-  useMetaTags({ title: t.common.search, description: t.search.description, url: localizePath("/search", language) })
+  const location = useLocation()
+  const navigate = useNavigate()
+  const postsPath = localizePath(`/posts${location.search}`, language)
 
-  const [query, setQuery] = useState("")
-  const [dateFrom, setDateFrom] = useState("")
-  const [dateTo, setDateTo] = useState("")
-  const [selectedTag, setSelectedTag] = useState("")
+  useMetaTags({
+    title: t.common.posts,
+    description: t.posts.description,
+    url: localizePath("/posts", language),
+  })
 
-  const allTags = getAllTags(language)
-  const hasFilters = query || dateFrom || dateTo || selectedTag
-
-  const results = hasFilters
-    ? advancedSearch({ query, dateFrom, dateTo, tag: selectedTag, language })
-    : []
-
-  function clearFilters() {
-    setQuery("")
-    setDateFrom("")
-    setDateTo("")
-    setSelectedTag("")
-  }
+  useEffect(() => {
+    navigate(postsPath, { replace: true })
+  }, [navigate, postsPath])
 
   return (
     <PageContainer>
-      <h1 className="text-4xl font-bold tracking-tight mb-8">{t.common.search}</h1>
-
-      <div className="space-y-4 mb-8">
-        <div className="relative">
-          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
-          <Input
-            placeholder={t.search.placeholder}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="pl-9"
-          />
-        </div>
-
-        <div className="flex gap-3">
-          <div className="flex-1">
-            <label className="text-xs text-muted-foreground mb-1 block">{t.search.dateFrom}</label>
-            <DatePicker value={dateFrom} onChange={setDateFrom} placeholder={t.search.dateFrom} />
-          </div>
-          <div className="flex-1">
-            <label className="text-xs text-muted-foreground mb-1 block">{t.search.dateTo}</label>
-            <DatePicker value={dateTo} onChange={setDateTo} placeholder={t.search.dateTo} />
-          </div>
-        </div>
-
-        <div>
-          <label className="text-xs text-muted-foreground mb-2 block">{t.search.tagFilter}</label>
-          <div className="flex flex-wrap gap-1.5">
-            {allTags.map((tag) => (
-              <Badge
-                key={tag}
-                variant={selectedTag === tag ? "default" : "secondary"}
-                className="cursor-pointer"
-                onClick={() => setSelectedTag(selectedTag === tag ? "" : tag)}
-              >
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        </div>
-
-        {hasFilters && (
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">
-              {t.search.resultCount(results.length)}
-            </span>
-            <Button variant="ghost" size="sm" onClick={clearFilters}>
-              <XIcon className="size-3 mr-1" />
-              {t.search.reset}
-            </Button>
-          </div>
-        )}
+      <div className="space-y-4">
+        <h1 className="text-4xl font-bold tracking-tight">{t.search.redirectTitle}</h1>
+        <p className="text-muted-foreground">{t.search.redirectDescription}</p>
+        <Button asChild>
+          <Link to={postsPath} replace>
+            {t.search.goToPosts}
+          </Link>
+        </Button>
       </div>
-
-      {hasFilters ? (
-        <PostList posts={results} emptyMessage={t.search.noResults} />
-      ) : (
-        <p className="text-muted-foreground text-sm">{t.search.searchGuide}</p>
-      )}
     </PageContainer>
   )
 }

--- a/src/pages/TagsPage.tsx
+++ b/src/pages/TagsPage.tsx
@@ -1,67 +1,396 @@
+import { useMemo } from "react"
 import { Link, useSearchParams } from "react-router-dom"
+import { SearchIcon, XIcon } from "lucide-react"
 import { useMetaTags } from "@/hooks/useMetaTags"
 import { getAllPosts } from "@/lib/posts"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { PostList } from "@/components/PostList"
+import { Input } from "@/components/ui/input"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { PageContainer } from "@/components/PageContainer"
 import { useLanguage } from "@/i18n"
-import { localizePath } from "@/lib/i18n-routing"
+import { localizePath, postPath } from "@/lib/i18n-routing"
+import type { PostMeta } from "@/types/post"
+
+type TagSort = "popular" | "recent" | "name"
+
+interface TagStats {
+  tag: string
+  count: number
+  latestDate: string
+  posts: PostMeta[]
+}
+
+interface TagGroup {
+  id: string
+  label: string
+  tags: string[]
+}
+
+const tagSorts = new Set<TagSort>(["popular", "recent", "name"])
+
+const TAG_GROUPS: TagGroup[] = [
+  {
+    id: "backend",
+    label: "Backend",
+    tags: ["java", "spring-boot", "spring", "authentication", "oauth", "jwt", "architecture", "payment"],
+  },
+  {
+    id: "infra",
+    label: "Infra / DevOps",
+    tags: ["devops", "kubernetes", "migration", "aws", "gcp", "observability", "argocd", "gitops"],
+  },
+  {
+    id: "frontend",
+    label: "Frontend",
+    tags: ["react", "typescript", "shadcn-ui", "css", "tailwind", "seo", "ux"],
+  },
+  {
+    id: "ai-blog",
+    label: "AI / Blog",
+    tags: ["ai", "spring-ai", "llm", "prompt-engineering", "blog", "google-analytics", "view-transitions"],
+  },
+]
+
+function toTagSort(value: string | null): TagSort {
+  return tagSorts.has(value as TagSort) ? (value as TagSort) : "popular"
+}
+
+function buildTagStats(posts: PostMeta[]): TagStats[] {
+  const tagMap = new Map<string, TagStats>()
+
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      const current = tagMap.get(tag)
+      if (current) {
+        current.count += 1
+        current.latestDate = post.date > current.latestDate ? post.date : current.latestDate
+        current.posts.push(post)
+      } else {
+        tagMap.set(tag, {
+          tag,
+          count: 1,
+          latestDate: post.date,
+          posts: [post],
+        })
+      }
+    }
+  }
+
+  return [...tagMap.values()].map((stats) => ({
+    ...stats,
+    posts: [...stats.posts].sort((a, b) => (a.date > b.date ? -1 : 1)),
+  }))
+}
+
+function sortTagStats(tags: TagStats[], sortMode: TagSort) {
+  return [...tags].sort((a, b) => {
+    if (sortMode === "name") return a.tag.localeCompare(b.tag)
+    if (sortMode === "recent") {
+      if (a.latestDate !== b.latestDate) return b.latestDate.localeCompare(a.latestDate)
+      if (a.count !== b.count) return b.count - a.count
+      return a.tag.localeCompare(b.tag)
+    }
+
+    if (a.count !== b.count) return b.count - a.count
+    if (a.latestDate !== b.latestDate) return b.latestDate.localeCompare(a.latestDate)
+    return a.tag.localeCompare(b.tag)
+  })
+}
+
+function matchesQuery(stats: TagStats, query: string) {
+  return stats.tag.toLowerCase().includes(query.toLowerCase())
+}
 
 export function TagsPage() {
   const { language, t } = useLanguage()
   useMetaTags({ title: t.common.tags, description: t.tags.description, url: localizePath("/tags", language) })
-  const posts = getAllPosts(language)
+
+  const posts = useMemo(() => getAllPosts(language), [language])
   const [searchParams, setSearchParams] = useSearchParams()
-  const selectedTag = searchParams.get("tag")
+  const selectedTag = searchParams.get("tag") ?? ""
+  const query = searchParams.get("q") ?? ""
+  const sortMode = toTagSort(searchParams.get("sort"))
 
-  const allTags = Array.from(new Set(posts.flatMap((p) => p.tags))).sort()
+  const tagStats = useMemo(() => buildTagStats(posts), [posts])
+  const statsByTag = useMemo(() => new Map(tagStats.map((stats) => [stats.tag, stats])), [tagStats])
+  const selectedStats = selectedTag ? statsByTag.get(selectedTag) : undefined
 
-  const filteredPosts = selectedTag
-    ? posts.filter((p) => p.tags.includes(selectedTag))
-    : []
+  const matchingTags = useMemo(() => {
+    const trimmedQuery = query.trim()
+    const filtered = trimmedQuery ? tagStats.filter((stats) => matchesQuery(stats, trimmedQuery)) : tagStats
+    return sortTagStats(filtered, sortMode)
+  }, [query, sortMode, tagStats])
 
-  function clearTag() {
-    setSearchParams({})
+  const visibleTopTags = query.trim() ? matchingTags : matchingTags.slice(0, 12)
+  const activeStats = selectedStats ?? matchingTags[0] ?? null
+
+  const groupedTags = useMemo(() => {
+    const groupedTagNames = new Set(TAG_GROUPS.flatMap((group) => group.tags))
+    const queryValue = query.trim()
+
+    const groups = TAG_GROUPS.map((group) => ({
+      ...group,
+      tags: sortTagStats(
+        group.tags
+          .map((tag) => statsByTag.get(tag))
+          .filter((stats): stats is TagStats => Boolean(stats))
+          .filter((stats) => !queryValue || matchesQuery(stats, queryValue)),
+        sortMode
+      ),
+    })).filter((group) => group.tags.length > 0)
+
+    const ungrouped = sortTagStats(
+      tagStats
+        .filter((stats) => !groupedTagNames.has(stats.tag))
+        .filter((stats) => !queryValue || matchesQuery(stats, queryValue)),
+      sortMode
+    )
+
+    if (ungrouped.length > 0) {
+      groups.push({
+        id: "etc",
+        label: t.tags.ungrouped,
+        tags: queryValue ? ungrouped : ungrouped.slice(0, 10),
+      })
+    }
+
+    return groups
+  }, [query, sortMode, statsByTag, t.tags.ungrouped, tagStats])
+
+  const relatedTags = useMemo(() => {
+    if (!activeStats) return []
+
+    const related = new Map<string, number>()
+    for (const post of activeStats.posts) {
+      for (const tag of post.tags) {
+        if (tag === activeStats.tag) continue
+        related.set(tag, (related.get(tag) ?? 0) + 1)
+      }
+    }
+
+    return [...related.entries()]
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+      .slice(0, 6)
+  }, [activeStats])
+
+  function updateParam(key: string, value: string, defaultValue = "") {
+    const next = new URLSearchParams(searchParams)
+    if (!value || value === defaultValue) {
+      next.delete(key)
+    } else {
+      next.set(key, value)
+    }
+    setSearchParams(next, { replace: true })
   }
 
-  return (
-    <PageContainer>
-      <h1 className="text-4xl font-bold tracking-tight mb-8">{t.common.tags}</h1>
+  function resetFilters() {
+    setSearchParams({}, { replace: true })
+  }
 
-      {!selectedTag ? (
-        <div className="flex flex-wrap gap-3">
-          {allTags.map((tag) => (
-            <Link key={tag} to={localizePath(`/tags?tag=${encodeURIComponent(tag)}`, language)} viewTransition>
-              <Badge
-                variant="secondary"
-                className="text-sm px-3 py-1 cursor-pointer hover:bg-accent"
-              >
-                {tag}
-              </Badge>
-            </Link>
-          ))}
-          {allTags.length === 0 && (
-            <p className="text-muted-foreground">{t.tags.noTags}</p>
+  function tagsPathFor(tag: string) {
+    const next = new URLSearchParams(searchParams)
+    next.set("tag", tag)
+    const suffix = next.toString()
+    return localizePath(`/tags${suffix ? `?${suffix}` : ""}`, language)
+  }
+
+  const hasFilters = Boolean(query.trim() || selectedTag || sortMode !== "popular")
+
+  return (
+    <PageContainer variant="wide">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-4xl font-bold tracking-tight">{t.common.tags}</h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            {t.tags.summary(posts.length, tagStats.length)}
+          </p>
+        </div>
+
+        {selectedStats && (
+          <Badge variant="outline" className="w-fit rounded-full px-3 py-1 text-sm">
+            {t.tags.selectedLabel(selectedStats.tag)}
+          </Badge>
+        )}
+      </div>
+
+      <div className="mb-8 space-y-3">
+        <div className="relative">
+          <SearchIcon className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => updateParam("q", event.target.value)}
+            placeholder={t.tags.searchPlaceholder}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <ToggleGroup
+            type="single"
+            value={sortMode}
+            onValueChange={(value) => { if (value) updateParam("sort", value, "popular") }}
+            variant="outline"
+            size="sm"
+          >
+            <ToggleGroupItem value="popular">{t.tags.sortPopular}</ToggleGroupItem>
+            <ToggleGroupItem value="recent">{t.tags.sortRecent}</ToggleGroupItem>
+            <ToggleGroupItem value="name">{t.tags.sortName}</ToggleGroupItem>
+          </ToggleGroup>
+
+          {hasFilters && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="w-fit self-start sm:self-auto"
+              onClick={resetFilters}
+            >
+              <XIcon className="size-3" />
+              {t.tags.reset}
+            </Button>
           )}
         </div>
+      </div>
+
+      {tagStats.length === 0 ? (
+        <p className="text-muted-foreground">{t.tags.noTags}</p>
       ) : (
-        <div>
-          <div className="flex items-center gap-4 mb-6">
-            <span className="text-lg font-medium">
-              <Badge variant="default" className="text-base px-3 py-1">
-                {selectedTag}
-              </Badge>
-            </span>
-            <Button variant="ghost" size="sm" onClick={clearTag}>
-              {t.tags.allTags}
-            </Button>
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="space-y-9">
+            <section>
+              <div className="mb-3 flex items-center justify-between gap-4">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  {t.tags.topTags}
+                </h2>
+                <span className="hidden text-xs text-muted-foreground sm:inline">{t.tags.topTagsNote}</span>
+              </div>
+
+              {visibleTopTags.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t.tags.noMatchingTags}</p>
+              ) : (
+                <div className="border-t">
+                  {visibleTopTags.map((stats) => (
+                    <Link
+                      key={stats.tag}
+                      to={tagsPathFor(stats.tag)}
+                      viewTransition
+                      className="grid min-h-14 grid-cols-1 gap-1 border-b py-3 transition-colors hover:bg-accent/40 sm:grid-cols-[minmax(0,1fr)_5rem_7rem] sm:items-center sm:gap-4 sm:px-0"
+                    >
+                      <span className="flex min-w-0 items-center gap-2 font-medium">
+                        <span
+                          className={
+                            selectedTag === stats.tag
+                              ? "size-2 rounded-full bg-foreground"
+                              : "size-2 rounded-full bg-muted-foreground/25"
+                          }
+                        />
+                        <span className="truncate">{stats.tag}</span>
+                      </span>
+                      <span className="text-sm text-muted-foreground">{t.tags.postCount(stats.count)}</span>
+                      <time dateTime={stats.latestDate} className="text-sm text-muted-foreground">
+                        {stats.latestDate}
+                      </time>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                {t.tags.topicGroups}
+              </h2>
+
+              {groupedTags.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t.tags.noMatchingTags}</p>
+              ) : (
+                <div className="grid gap-x-8 gap-y-7 sm:grid-cols-2">
+                  {groupedTags.map((group) => (
+                    <div key={group.id} className="min-w-0">
+                      <h3 className="mb-3 text-base font-semibold">{group.label}</h3>
+                      <div className="border-t">
+                        {group.tags.map((stats) => (
+                          <Link
+                            key={stats.tag}
+                            to={tagsPathFor(stats.tag)}
+                            viewTransition
+                            className="flex h-8 items-center justify-between gap-3 border-b text-sm transition-colors hover:bg-accent/40"
+                          >
+                            <span className="truncate">{stats.tag}</span>
+                            <span className="shrink-0 text-muted-foreground">{t.tags.postCount(stats.count)}</span>
+                          </Link>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
           </div>
 
-          <PostList
-            posts={filteredPosts}
-            emptyMessage={t.tags.noPostsWithTag}
-          />
+          {activeStats && (
+            <aside className="border-t pt-8 lg:sticky lg:top-20 lg:border-l lg:border-t-0 lg:pl-7 lg:pt-0">
+              <div className="mb-2 flex items-start justify-between gap-3">
+                <h2 className="break-all text-3xl font-bold tracking-tight">{activeStats.tag}</h2>
+                <Badge className="shrink-0 rounded-full">{t.tags.postCount(activeStats.count)}</Badge>
+              </div>
+
+              <p className="mb-6 text-sm leading-6 text-muted-foreground">
+                {t.tags.selectedDescription(activeStats.tag)}
+              </p>
+
+              {relatedTags.length > 0 && (
+                <div className="mb-6">
+                  <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                    {t.tags.relatedTags}
+                  </h3>
+                  <div className="flex flex-wrap gap-1.5">
+                    {relatedTags.map(({ tag }) => (
+                      <Link key={tag} to={tagsPathFor(tag)} viewTransition>
+                        <Badge variant="secondary" className="rounded-full">
+                          {tag}
+                        </Badge>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  {t.tags.recentPosts}
+                </h3>
+                <div className="border-t">
+                  {activeStats.posts.slice(0, 3).map((post) => (
+                    <Link
+                      key={`${post.language}:${post.slug}`}
+                      to={postPath(post.slug, post.language)}
+                      viewTransition
+                      className="block border-b py-4 transition-colors hover:bg-accent/40"
+                    >
+                      <time dateTime={post.date} className="text-xs text-muted-foreground">
+                        {post.date}
+                      </time>
+                      <h4 className="mt-1 line-clamp-2 text-sm font-semibold leading-5">{post.title}</h4>
+                      {post.description && (
+                        <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                          {post.description}
+                        </p>
+                      )}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+
+              <Button asChild variant="outline" className="mt-5 w-full">
+                <Link to={localizePath(`/posts?tag=${encodeURIComponent(activeStats.tag)}`, language)}>
+                  {t.tags.viewInPosts(activeStats.tag)}
+                </Link>
+              </Button>
+            </aside>
+          )}
         </div>
       )}
     </PageContainer>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -120,7 +120,7 @@ function sitemapPlugin(): Plugin {
       const koPosts = readPosts("ko")
       const enPosts = readPosts("en")
       const enPostSlugs = new Set(enPosts.map((p) => p.slug))
-      const staticPages = ["/", "/posts/", "/tags/", "/series/", "/search/", "/analytics/", "/about/"]
+      const staticPages = ["/", "/posts/", "/tags/", "/series/", "/analytics/", "/about/"]
       const today = new Date().toISOString().split("T")[0]
 
       function alternateEntry(hreflang: string, href: string) {


### PR DESCRIPTION
## 목적

글이 많아질수록 단순 목록과 별도 검색 메뉴가 중복되어 보이는 문제를 줄이고, 글 목록과 태그 탐색의 역할을 분리합니다.

## 내용(의도 포함)

- 검색 메뉴를 제거하고 `/posts`에 검색, 정렬, 태그/연도 필터를 통합했습니다.
- 기존 `/search` 경로는 `/posts`로 이동하는 호환 경로로 남기고, noindex 및 canonical을 `/posts/`로 맞췄습니다.
- `/tags`를 단순 태그 배지 나열에서 태그별 글 수, 최신 글 날짜, 주제 그룹, 관련 태그, 최근 글을 보여주는 탐색 허브로 개편했습니다.
- README 라우트 설명과 ko/en 번역 문구를 함께 갱신했습니다.

## 성공기준

- `npm run type-check` 통과
- `npm run lint` 통과, 기존 warning 14개 유지
- `npm run build` 통과, hydrated SSG 98 pages 생성 확인
- `git diff --check origin/main...HEAD` 통과
- Chrome headless로 `/tags/?tag=java` 데스크톱/모바일 화면 캡처 확인
