### PR TITLE
feat(series): 시리즈 메뉴 탐색 경험 개선

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -77,8 +77,25 @@ export interface Translations {
   }
   series: {
     description: string
+    summary: (postCount: number, seriesCount: number) => string
+    searchPlaceholder: string
+    sortRecent: string
+    sortCount: string
+    sortName: string
+    reset: string
+    selectedLabel: (series: string) => string
+    topSeries: string
+    topSeriesNote: string
+    topicGroups: string
+    ungrouped: string
     postCount: (count: number, date: string) => string
+    postCountShort: (count: number) => string
+    fallbackDescription: (series: string) => string
+    readingPath: string
+    relatedTags: string
+    startReading: string
     noSeries: string
+    noMatchingSeries: string
     allSeries: string
     noPostsInSeries: string
   }
@@ -270,8 +287,25 @@ export const ko: Translations = {
   },
   series: {
     description: "시리즈별 블로그 글 목록",
+    summary: (postCount, seriesCount) => `${postCount}개의 글이 ${seriesCount}개의 시리즈로 정리되어 있습니다.`,
+    searchPlaceholder: "시리즈, 태그, 설명으로 검색",
+    sortRecent: "최근순",
+    sortCount: "글 많은순",
+    sortName: "이름순",
+    reset: "초기화",
+    selectedLabel: (series) => `선택됨 · ${series}`,
+    topSeries: "주요 시리즈",
+    topSeriesNote: "최근 업데이트와 글 수 기준",
+    topicGroups: "주제 그룹",
+    ungrouped: "기타",
     postCount: (count, date) => `${count}개의 글 · ${date}`,
+    postCountShort: (count) => `${count}편`,
+    fallbackDescription: (series) => `${series} 시리즈의 글을 순서대로 모아 봅니다.`,
+    readingPath: "읽기 순서",
+    relatedTags: "관련 태그",
+    startReading: "첫 글부터 읽기",
     noSeries: "시리즈가 없습니다.",
+    noMatchingSeries: "조건에 맞는 시리즈가 없습니다.",
     allSeries: "전체 시리즈",
     noPostsInSeries: "해당 시리즈의 글이 없습니다.",
   },
@@ -463,8 +497,25 @@ export const en: Translations = {
   },
   series: {
     description: "Blog posts by series",
+    summary: (postCount, seriesCount) => `${postCount} post${postCount !== 1 ? "s" : ""} are organized into ${seriesCount} series.`,
+    searchPlaceholder: "Search series, tags, or descriptions",
+    sortRecent: "Recent",
+    sortCount: "Most posts",
+    sortName: "A-Z",
+    reset: "Reset",
+    selectedLabel: (series) => `Selected · ${series}`,
+    topSeries: "Top Series",
+    topSeriesNote: "Sorted by recent updates and post count",
+    topicGroups: "Topic Groups",
+    ungrouped: "Other",
     postCount: (count, date) => `${count} post${count !== 1 ? "s" : ""} · ${date}`,
+    postCountShort: (count) => `${count} post${count !== 1 ? "s" : ""}`,
+    fallbackDescription: (series) => `Read the ${series} series in order.`,
+    readingPath: "Reading Path",
+    relatedTags: "Related Tags",
+    startReading: "Start reading",
     noSeries: "No series yet.",
+    noMatchingSeries: "No series match these filters.",
     allSeries: "All series",
     noPostsInSeries: "No posts in this series.",
   },

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -198,32 +198,68 @@ export interface SeriesInfo {
   name: string
   postCount: number
   firstDate: string
+  latestDate: string
+  description: string
+  tags: string[]
+  posts: PostMeta[]
 }
 
 export function getAllSeries(language: Language = "ko"): SeriesInfo[] {
   const posts = getAllPosts(language)
-  const seriesMap = new Map<string, { count: number; firstDate: string }>()
+  const seriesMap = new Map<string, { posts: PostMeta[]; firstDate: string; latestDate: string }>()
 
   for (const post of posts) {
     if (!post.series) continue
     const existing = seriesMap.get(post.series)
     if (existing) {
-      existing.count++
+      existing.posts.push(post)
       if (post.date < existing.firstDate) existing.firstDate = post.date
+      if (post.date > existing.latestDate) existing.latestDate = post.date
     } else {
-      seriesMap.set(post.series, { count: 1, firstDate: post.date })
+      seriesMap.set(post.series, { posts: [post], firstDate: post.date, latestDate: post.date })
     }
   }
 
   return [...seriesMap.entries()]
-    .map(([name, { count, firstDate }]) => ({ name, postCount: count, firstDate }))
-    .sort((a, b) => (a.firstDate > b.firstDate ? -1 : 1))
+    .map(([name, { posts, firstDate, latestDate }]) => {
+      const orderedPosts = sortSeriesPosts(posts)
+      const tagCounts = new Map<string, number>()
+      for (const post of orderedPosts) {
+        for (const tag of post.tags) {
+          tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1)
+        }
+      }
+
+      return {
+        name,
+        postCount: orderedPosts.length,
+        firstDate,
+        latestDate,
+        description: orderedPosts[0]?.description ?? "",
+        tags: [...tagCounts.entries()]
+          .sort(([a, aCount], [b, bCount]) => bCount - aCount || a.localeCompare(b))
+          .map(([tag]) => tag),
+        posts: orderedPosts,
+      }
+    })
+    .sort((a, b) => {
+      if (a.latestDate !== b.latestDate) return b.latestDate.localeCompare(a.latestDate)
+      return a.name.localeCompare(b.name)
+    })
 }
 
 export function getSeriesPosts(seriesName: string, language: Language = "ko"): PostMeta[] {
-  return getAllPosts(language)
-    .filter((p) => p.series === seriesName)
-    .sort((a, b) => (a.seriesOrder ?? 0) - (b.seriesOrder ?? 0))
+  return sortSeriesPosts(getAllPosts(language).filter((p) => p.series === seriesName))
+}
+
+function sortSeriesPosts(posts: PostMeta[]): PostMeta[] {
+  return [...posts].sort((a, b) => {
+    const aOrder = a.seriesOrder ?? Number.MAX_SAFE_INTEGER
+    const bOrder = b.seriesOrder ?? Number.MAX_SAFE_INTEGER
+    if (aOrder !== bOrder) return aOrder - bOrder
+    if (a.date !== b.date) return a.date > b.date ? -1 : 1
+    return a.title.localeCompare(b.title)
+  })
 }
 
 export function getAdjacentPosts(slug: string, language: Language = "ko"): { prev: PostMeta | null; next: PostMeta | null } {

--- a/src/pages/SeriesPage.tsx
+++ b/src/pages/SeriesPage.tsx
@@ -1,73 +1,358 @@
+import { useMemo } from "react"
 import { Link, useSearchParams } from "react-router-dom"
+import { SearchIcon, XIcon } from "lucide-react"
 import { useMetaTags } from "@/hooks/useMetaTags"
-import { getAllSeries, getSeriesPosts } from "@/lib/posts"
+import { getAllPosts, getAllSeries, type SeriesInfo } from "@/lib/posts"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
-import { PostList } from "@/components/PostList"
+import { Input } from "@/components/ui/input"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { PageContainer } from "@/components/PageContainer"
 import { useLanguage } from "@/i18n"
-import { localizePath } from "@/lib/i18n-routing"
+import { localizePath, postPath } from "@/lib/i18n-routing"
+
+type SeriesSort = "recent" | "count" | "name"
+
+interface SeriesGroup {
+  id: string
+  label: string
+  tags: string[]
+}
+
+const seriesSorts = new Set<SeriesSort>(["recent", "count", "name"])
+
+const SERIES_GROUPS: SeriesGroup[] = [
+  {
+    id: "backend-auth",
+    label: "Backend / Auth",
+    tags: ["authentication", "oauth", "jwt", "payment", "java"],
+  },
+  {
+    id: "infra",
+    label: "Infra / DevOps",
+    tags: ["devops", "kubernetes", "migration", "aws", "gcp", "observability", "argocd", "gitops"],
+  },
+  {
+    id: "frontend-ai",
+    label: "Frontend / AI",
+    tags: ["react", "typescript", "blog", "seo", "ux", "ai", "spring-ai", "llm"],
+  },
+]
+
+function toSeriesSort(value: string | null): SeriesSort {
+  return seriesSorts.has(value as SeriesSort) ? (value as SeriesSort) : "recent"
+}
+
+function sortSeries(series: SeriesInfo[], sortMode: SeriesSort) {
+  return [...series].sort((a, b) => {
+    if (sortMode === "name") return a.name.localeCompare(b.name)
+    if (sortMode === "count") {
+      if (a.postCount !== b.postCount) return b.postCount - a.postCount
+      if (a.latestDate !== b.latestDate) return b.latestDate.localeCompare(a.latestDate)
+      return a.name.localeCompare(b.name)
+    }
+
+    if (a.latestDate !== b.latestDate) return b.latestDate.localeCompare(a.latestDate)
+    if (a.postCount !== b.postCount) return b.postCount - a.postCount
+    return a.name.localeCompare(b.name)
+  })
+}
+
+function matchesQuery(series: SeriesInfo, query: string) {
+  const q = query.toLowerCase()
+  return (
+    series.name.toLowerCase().includes(q) ||
+    series.description.toLowerCase().includes(q) ||
+    series.tags.some((tag) => tag.toLowerCase().includes(q)) ||
+    series.posts.some((post) => (
+      post.title.toLowerCase().includes(q) ||
+      post.description.toLowerCase().includes(q)
+    ))
+  )
+}
+
+function getGroupScore(series: SeriesInfo, group: SeriesGroup) {
+  const groupTags = new Set(group.tags)
+  return series.tags.reduce((score, tag) => score + (groupTags.has(tag) ? 1 : 0), 0)
+}
 
 export function SeriesPage() {
   const { language, t } = useLanguage()
   useMetaTags({ title: t.common.series, description: t.series.description, url: localizePath("/series", language) })
+
   const [searchParams, setSearchParams] = useSearchParams()
-  const selectedSeries = searchParams.get("name")
+  const selectedSeriesName = searchParams.get("name") ?? ""
+  const query = searchParams.get("q") ?? ""
+  const sortMode = toSeriesSort(searchParams.get("sort"))
 
-  const allSeries = getAllSeries(language)
-  const seriesPosts = selectedSeries ? getSeriesPosts(selectedSeries, language) : []
+  const posts = useMemo(() => getAllPosts(language), [language])
+  const allSeries = useMemo(() => getAllSeries(language), [language])
+  const seriesByName = useMemo(() => new Map(allSeries.map((series) => [series.name, series])), [allSeries])
+  const selectedSeries = selectedSeriesName ? seriesByName.get(selectedSeriesName) : undefined
 
-  function clearSeries() {
-    setSearchParams({})
+  const matchingSeries = useMemo(() => {
+    const trimmedQuery = query.trim()
+    const filtered = trimmedQuery ? allSeries.filter((series) => matchesQuery(series, trimmedQuery)) : allSeries
+    return sortSeries(filtered, sortMode)
+  }, [allSeries, query, sortMode])
+
+  const activeSeries = selectedSeries ?? matchingSeries[0] ?? null
+
+  const groupedSeries = useMemo(() => {
+    const queryValue = query.trim()
+    const groups = SERIES_GROUPS.map((group) => ({ ...group, series: [] as SeriesInfo[] }))
+    const ungrouped: SeriesInfo[] = []
+
+    for (const series of matchingSeries) {
+      const [bestGroup] = groups
+        .map((group, index) => ({ group, index, score: getGroupScore(series, group) }))
+        .sort((a, b) => b.score - a.score || a.index - b.index)
+
+      if (bestGroup && bestGroup.score > 0) {
+        bestGroup.group.series.push(series)
+      } else {
+        ungrouped.push(series)
+      }
+    }
+
+    const visibleGroups = groups.filter((group) => group.series.length > 0)
+    if (ungrouped.length > 0) {
+      visibleGroups.push({
+        id: "etc",
+        label: t.series.ungrouped,
+        tags: [],
+        series: queryValue ? ungrouped : ungrouped.slice(0, 8),
+      })
+    }
+
+    return visibleGroups
+  }, [matchingSeries, query, t.series.ungrouped])
+
+  function updateParam(key: string, value: string, defaultValue = "") {
+    const next = new URLSearchParams(searchParams)
+    if (!value || value === defaultValue) {
+      next.delete(key)
+    } else {
+      next.set(key, value)
+    }
+    setSearchParams(next, { replace: true })
   }
 
-  return (
-    <PageContainer>
-      <h1 className="text-4xl font-bold tracking-tight mb-8">{t.common.series}</h1>
+  function resetFilters() {
+    setSearchParams({}, { replace: true })
+  }
 
-      {!selectedSeries ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {allSeries.map((series) => (
-            <Link
-              key={series.name}
-              to={localizePath(`/series?name=${encodeURIComponent(series.name)}`, language)}
-              viewTransition
-              className="group"
+  function seriesPathFor(seriesName: string) {
+    const next = new URLSearchParams(searchParams)
+    next.set("name", seriesName)
+    const suffix = next.toString()
+    return localizePath(`/series${suffix ? `?${suffix}` : ""}`, language)
+  }
+
+  const hasFilters = Boolean(query.trim() || selectedSeriesName || sortMode !== "recent")
+
+  return (
+    <PageContainer variant="wide">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-4xl font-bold tracking-tight">{t.common.series}</h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            {t.series.summary(posts.length, allSeries.length)}
+          </p>
+        </div>
+
+        {activeSeries && (
+          <Badge variant="outline" className="w-fit rounded-full px-3 py-1 text-sm">
+            {t.series.selectedLabel(activeSeries.name)}
+          </Badge>
+        )}
+      </div>
+
+      <div className="mb-8 space-y-3">
+        <div className="relative">
+          <SearchIcon className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => updateParam("q", event.target.value)}
+            placeholder={t.series.searchPlaceholder}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <ToggleGroup
+            type="single"
+            value={sortMode}
+            onValueChange={(value) => { if (value) updateParam("sort", value, "recent") }}
+            variant="outline"
+            size="sm"
+          >
+            <ToggleGroupItem value="recent">{t.series.sortRecent}</ToggleGroupItem>
+            <ToggleGroupItem value="count">{t.series.sortCount}</ToggleGroupItem>
+            <ToggleGroupItem value="name">{t.series.sortName}</ToggleGroupItem>
+          </ToggleGroup>
+
+          {hasFilters && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="w-fit self-start sm:self-auto"
+              onClick={resetFilters}
             >
-              <Card className="h-full transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
-                <CardHeader>
-                  <CardTitle className="text-base group-hover:text-primary transition-colors">
-                    {series.name}
-                  </CardTitle>
-                  <CardDescription>
-                    {t.series.postCount(series.postCount, series.firstDate)}
-                  </CardDescription>
-                </CardHeader>
-              </Card>
-            </Link>
-          ))}
-          {allSeries.length === 0 && (
-            <p className="text-muted-foreground">{t.series.noSeries}</p>
+              <XIcon className="size-3" />
+              {t.series.reset}
+            </Button>
           )}
         </div>
+      </div>
+
+      {allSeries.length === 0 ? (
+        <p className="text-muted-foreground">{t.series.noSeries}</p>
       ) : (
-        <div>
-          <div className="flex items-center gap-4 mb-6">
-            <span className="text-lg font-medium">
-              <Badge variant="default" className="text-base px-3 py-1">
-                {selectedSeries}
-              </Badge>
-            </span>
-            <Button variant="ghost" size="sm" onClick={clearSeries}>
-              {t.series.allSeries}
-            </Button>
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="space-y-9">
+            <section>
+              <div className="mb-3 flex items-center justify-between gap-4">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  {t.series.topSeries}
+                </h2>
+                <span className="hidden text-xs text-muted-foreground sm:inline">{t.series.topSeriesNote}</span>
+              </div>
+
+              {matchingSeries.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t.series.noMatchingSeries}</p>
+              ) : (
+                <div className="border-t">
+                  {matchingSeries.map((series) => (
+                    <Link
+                      key={series.name}
+                      to={seriesPathFor(series.name)}
+                      viewTransition
+                      className="grid min-h-20 grid-cols-1 gap-1 border-b py-4 transition-colors hover:bg-accent/40 sm:grid-cols-[minmax(0,1fr)_5rem_7rem] sm:items-center sm:gap-4 sm:px-0"
+                    >
+                      <span className="min-w-0">
+                        <span className="flex min-w-0 items-center gap-2 font-medium">
+                          <span
+                            className={
+                              activeSeries?.name === series.name
+                                ? "size-2 shrink-0 rounded-full bg-foreground"
+                                : "size-2 shrink-0 rounded-full bg-muted-foreground/25"
+                            }
+                          />
+                          <span className="truncate">{series.name}</span>
+                        </span>
+                        <span className="mt-1 block line-clamp-2 break-all pl-4 text-sm leading-6 text-muted-foreground">
+                          {series.description || t.series.fallbackDescription(series.name)}
+                        </span>
+                      </span>
+                      <span className="text-sm text-muted-foreground">{t.series.postCountShort(series.postCount)}</span>
+                      <time dateTime={series.latestDate} className="text-sm text-muted-foreground">
+                        {series.latestDate}
+                      </time>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                {t.series.topicGroups}
+              </h2>
+
+              {groupedSeries.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t.series.noMatchingSeries}</p>
+              ) : (
+                <div className="grid gap-x-8 gap-y-7 sm:grid-cols-2">
+                  {groupedSeries.map((group) => (
+                    <div key={group.id} className="min-w-0">
+                      <h3 className="mb-3 text-base font-semibold">{group.label}</h3>
+                      <div className="border-t">
+                        {group.series.map((series) => (
+                          <Link
+                            key={series.name}
+                            to={seriesPathFor(series.name)}
+                            viewTransition
+                            className="flex h-8 items-center justify-between gap-3 border-b text-sm transition-colors hover:bg-accent/40"
+                          >
+                            <span className="truncate">{series.name}</span>
+                            <span className="shrink-0 text-muted-foreground">{t.series.postCountShort(series.postCount)}</span>
+                          </Link>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
           </div>
 
-          <PostList
-            posts={seriesPosts}
-            emptyMessage={t.series.noPostsInSeries}
-          />
+          {activeSeries && (
+            <aside className="border-t pt-8 lg:sticky lg:top-20 lg:border-l lg:border-t-0 lg:pl-7 lg:pt-0">
+              <div className="mb-2 flex items-start justify-between gap-3">
+                <h2 className="break-keep text-3xl font-bold tracking-tight">{activeSeries.name}</h2>
+                <Badge className="shrink-0 rounded-full">{t.series.postCountShort(activeSeries.postCount)}</Badge>
+              </div>
+
+              <p className="mb-6 break-all text-sm leading-6 text-muted-foreground">
+                {activeSeries.description || t.series.fallbackDescription(activeSeries.name)}
+              </p>
+
+              <div className="mb-6">
+                <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  {t.series.readingPath}
+                </h3>
+                <div className="border-t">
+                  {activeSeries.posts.map((post, index) => (
+                    <Link
+                      key={`${post.language}:${post.slug}`}
+                      to={postPath(post.slug, post.language)}
+                      viewTransition
+                      className="grid grid-cols-[1.5rem_minmax(0,1fr)] gap-2.5 border-b py-4 transition-colors hover:bg-accent/40"
+                    >
+                      <span className="flex size-6 items-center justify-center rounded-full bg-secondary text-xs font-semibold text-secondary-foreground">
+                        {index + 1}
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block line-clamp-2 text-sm font-semibold leading-5">{post.title}</span>
+                        {post.description && (
+                          <span className="mt-1 block line-clamp-2 break-all text-xs leading-5 text-muted-foreground">
+                            {post.description}
+                          </span>
+                        )}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+
+              {activeSeries.tags.length > 0 && (
+                <div className="mb-6">
+                  <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                    {t.series.relatedTags}
+                  </h3>
+                  <div className="flex flex-wrap gap-1.5">
+                    {activeSeries.tags.slice(0, 8).map((tag) => (
+                      <Link key={tag} to={localizePath(`/posts?tag=${encodeURIComponent(tag)}`, language)} viewTransition>
+                        <Badge variant="secondary" className="rounded-full">
+                          {tag}
+                        </Badge>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {activeSeries.posts[0] && (
+                <Button asChild variant="outline" className="w-full">
+                  <Link to={postPath(activeSeries.posts[0].slug, activeSeries.posts[0].language)} viewTransition>
+                    {t.series.startReading}
+                  </Link>
+                </Button>
+              )}
+            </aside>
+          )}
         </div>
       )}
     </PageContainer>


### PR DESCRIPTION
## 목적

시리즈 페이지를 단순 카드 목록에서 검색, 정렬, 주제 그룹, 읽기 순서를 제공하는 탐색 화면으로 개선합니다.

## 내용(의도 포함)

- 시리즈 목록을 현재 블로그 디자인 톤에 맞춘 리스트형 허브 UI로 개편했습니다.
- 시리즈명, 설명, 태그, 글 제목/설명 기반 검색과 최근순/글 많은순/이름순 정렬을 추가했습니다.
- 선택된 시리즈의 설명, 읽기 순서, 관련 태그, 첫 글 이동 버튼을 우측 패널로 제공해 연속 읽기 흐름을 강화했습니다.
- `getAllSeries`가 최신일, 대표 설명, 태그, 정렬된 글 목록을 함께 반환하도록 확장했습니다.
- 시리즈 화면에 필요한 한국어/영어 번역 키를 추가했습니다.

## 성공기준

- `npm run type-check` 통과
- `npm run lint` 통과. 기존 경고 14개만 남음
- `npm run build` 통과 및 SSG 98 pages 생성 확인
- `/series/` preview HTTP 200 확인
- 390px 모바일 emulation에서 `document.documentElement.scrollWidth === 390` 확인
