### PR TITLE
feat(resume): AI-native 개발 경험 보강

### DIFF
--- a/src/components/ResumePdf.tsx
+++ b/src/components/ResumePdf.tsx
@@ -10,6 +10,7 @@ import {
 } from "@react-pdf/renderer"
 import {
   PROFILE,
+  AI_NATIVE_WORKFLOW,
   SKILLS,
   COMPANIES,
   CERTIFICATIONS,
@@ -72,6 +73,11 @@ const s = StyleSheet.create({
   skillRow: { flexDirection: "row", marginBottom: 6 },
   skillCategory: { width: 92, fontSize: 8.5, fontWeight: 600, color: colors.primary },
   skillList: { flex: 1, fontSize: 8.5, color: colors.secondary },
+  workflowItem: { flexDirection: "row", marginBottom: 6, paddingLeft: 2 },
+  workflowBullet: { width: 9, fontSize: 8.5, color: colors.accent, lineHeight: 1.6 },
+  workflowContent: { flex: 1 },
+  workflowTitle: { fontSize: 8.5, fontWeight: 600, color: colors.primary, lineHeight: 1.6 },
+  workflowDescription: { fontSize: 8, color: colors.muted, lineHeight: 1.55 },
   // Company
   companyOuterFirst: { marginTop: 6 },
   companyHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "baseline", marginBottom: 3 },
@@ -186,7 +192,7 @@ export function ResumePdfDocument() {
         {/* Header */}
         <View style={s.header}>
           <Text style={s.name}>{PROFILE.name}</Text>
-          <Text style={s.role}>Backend Engineer</Text>
+          <Text style={s.role}>Software Engineer · AI-native Product Delivery</Text>
           <View style={s.contactRow}>
             <Link src={`mailto:${PROFILE.email}`} style={s.contactLink}>{PROFILE.email}</Link>
             <Text style={s.contactSep}>·</Text>
@@ -194,6 +200,18 @@ export function ResumePdfDocument() {
           </View>
           <Text style={s.intro}>{PROFILE.introduction}</Text>
         </View>
+
+        {/* AI-native Development */}
+        <Text style={s.sectionTitle}>AI-native Development</Text>
+        {AI_NATIVE_WORKFLOW.map((item) => (
+          <View key={item.title} style={s.workflowItem} wrap={false}>
+            <Text style={s.workflowBullet}>·</Text>
+            <View style={s.workflowContent}>
+              <Text style={s.workflowTitle}>{item.title}</Text>
+              <BoldText style={s.workflowDescription}>{item.description}</BoldText>
+            </View>
+          </View>
+        ))}
 
         {/* Experience */}
         <Text style={s.sectionTitle}>Experience</Text>

--- a/src/data/resume-i18n.ts
+++ b/src/data/resume-i18n.ts
@@ -1,17 +1,20 @@
 import type { Language } from "@/i18n"
 import {
   PROFILE,
+  AI_NATIVE_WORKFLOW,
   SKILLS,
   COMPANIES,
   CERTIFICATIONS,
   PROJECTS,
   type Certification,
+  type AiNativeWorkflowItem,
   type Company,
   type ProjectDetail,
 } from "@/data/resume"
 
 interface ResumeData {
   profile: typeof PROFILE
+  aiNativeWorkflow: AiNativeWorkflowItem[]
   skills: typeof SKILLS
   companies: Company[]
   certifications: Certification[]
@@ -22,8 +25,23 @@ const EN_PROFILE: typeof PROFILE = {
   ...PROFILE,
   name: "Hyukjun Yoon",
   introduction:
-    "I am a backend engineer who turns business requirements into product features such as payments, reservations, lessons, and notifications, then designs service structures that scale reliably.\nI have migrated legacy payment and authentication systems to Java/Spring and reshaped high-risk operational domains into observable, change-friendly systems.\nRecently, I have been applying LLM pipelines and AI code review automation in production to improve both product quality and development productivity.",
+    "I am a software engineer who centers on backend engineering and connects frontend and infrastructure work as needed to turn business requirements into production-ready product capabilities.\nI have redesigned legacy payment and authentication domains on Java/Spring and introduced LLM diagnostic pipelines and AI-powered CS automation in production, improving service reliability and operational efficiency.\nI treat generative AI as a development partner, not merely a code generator. I integrate it across requirements analysis, codebase exploration, design, implementation, testing, review, and documentation, while personally validating outcomes against official documentation, executable code, automated tests, and production data.",
 }
+
+const EN_AI_NATIVE_WORKFLOW: AiNativeWorkflowItem[] = [
+  {
+    title: "AI throughout the development lifecycle",
+    description: "I integrate generative AI agents into the daily development loop, from requirements analysis and codebase exploration to design, **backend/frontend implementation**, testing, code review, and documentation.",
+  },
+  {
+    title: "End-to-end product delivery",
+    description: "With Java/Spring as my backend foundation, I connect React/TypeScript interfaces, E2E tests, deployment, and observability to deliver complete product features.",
+  },
+  {
+    title: "Verifiable outcomes",
+    description: "I use MCP and official documentation to check current specifications, then validate AI-generated work through **compilation, automated tests, runtime logs, and production metrics** before adopting it.",
+  },
+]
 
 const EN_COMPANIES: Company[] = [
   {
@@ -157,10 +175,13 @@ const EN_PROJECTS: ProjectDetail[] = [
     company: "Day1 Company",
     name: "Payment System Redesign",
     period: "Mar 2025 - Sep 2025",
-    tech: ["Java", "Spring Boot", "Redis", "PortOne"],
+    tech: ["Java", "Spring Boot", "Redis", "PortOne", "Claude Code", "MCP"],
     tasks: [
       {
         content: "Migrated a legacy PHP payment system to Java/Spring while gradually moving from PortOne v1 to v2 with backward compatibility",
+      },
+      {
+        content: "Connected **PortOne MCP to Claude Code** to inspect V2 API and SDK specifications directly in the development context and used them to implement `PortoneV2Service`",
       },
       {
         content: "Separated payment approval, verification, and post-processing stages and redesigned the flow around APIs to simplify payment-state tracking and transaction boundaries",
@@ -455,6 +476,7 @@ const EN_PROJECTS: ProjectDetail[] = [
 
 const KO_RESUME: ResumeData = {
   profile: PROFILE,
+  aiNativeWorkflow: AI_NATIVE_WORKFLOW,
   skills: SKILLS,
   companies: COMPANIES,
   certifications: CERTIFICATIONS,
@@ -463,6 +485,7 @@ const KO_RESUME: ResumeData = {
 
 const EN_RESUME: ResumeData = {
   profile: EN_PROFILE,
+  aiNativeWorkflow: EN_AI_NATIVE_WORKFLOW,
   skills: SKILLS,
   companies: EN_COMPANIES,
   certifications: EN_CERTIFICATIONS,

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -39,6 +39,11 @@ export interface Certification {
   year: string
 }
 
+export interface AiNativeWorkflowItem {
+  title: string
+  description: string
+}
+
 export const PROFILE = {
   name: "윤혁준",
   phone: "010-6709-1540",
@@ -46,14 +51,31 @@ export const PROFILE = {
   linkedin: "https://www.linkedin.com/in/%ED%98%81%EC%A4%80-%EC%9C%A4-21a3bb22a/",
   email: "gurwns1540@gmail.com",
   introduction:
-    "비즈니스 요구를 결제·예약·수업·알림 같은 제품 기능으로 풀어내고, 안정적으로 확장되는 서비스 구조까지 설계하는 백엔드 엔지니어입니다.\n레거시 결제·인증 구조를 Java/Spring 기반으로 전환하고, 운영 리스크가 큰 도메인을 관측 가능하고 변경에 강한 구조로 정비해왔습니다.\n최근에는 LLM 파이프라인과 AI 코드리뷰 자동화를 프로덕션에 적용하며, 제품 품질과 개발 생산성을 함께 높이는 시스템을 만들고 있습니다.",
+    "백엔드를 중심으로 제품에 필요한 프론트엔드와 인프라까지 직접 연결하며, 비즈니스 요구를 실제 운영되는 기능으로 완성해온 소프트웨어 엔지니어입니다.\n결제·인증 같은 핵심 도메인의 레거시를 Java/Spring 기반으로 재설계하고, LLM 진단 파이프라인과 AI 기반 CS 자동화를 프로덕션에 적용해 서비스 안정성과 운영 효율을 개선했습니다.\n생성형 AI를 단순한 코드 생성 도구가 아닌 개발 파트너로 활용합니다. 요구사항 분석과 코드베이스 탐색부터 설계·구현·테스트·리뷰·문서화까지 개발 과정 전반에 통합하되, 최종 결과는 공식 문서와 코드 실행·자동화 테스트·운영 데이터로 직접 검증합니다.",
 }
+
+export const AI_NATIVE_WORKFLOW: AiNativeWorkflowItem[] = [
+  {
+    title: "개발 전 과정에 AI 활용",
+    description: "요구사항 분석과 코드베이스 탐색부터 설계, **BE/FE 구현**, 테스트, 코드 리뷰, 문서화까지 생성형 AI 에이전트를 일상적인 개발 루프에 통합합니다.",
+  },
+  {
+    title: "경계 없는 제품 전달",
+    description: "Java/Spring 백엔드를 중심으로 React/TypeScript 화면, E2E 테스트, 배포·관측까지 필요한 영역을 직접 연결해 기능을 끝까지 완성합니다.",
+  },
+  {
+    title: "검증 가능한 결과",
+    description: "MCP와 공식 문서로 최신 명세를 확인하고, AI가 만든 결과는 **컴파일·자동화 테스트·실행 로그·운영 지표**로 검증한 뒤 반영합니다.",
+  },
+]
 
 export const SKILLS: Record<string, string[]> = {
   Backend: ["Java", "Spring Boot", "QueryDSL", "MyBatis", "JPA", "Kafka"],
+  Frontend: ["React", "TypeScript", "Vite", "Tailwind CSS", "Playwright"],
   Infrastructure: ["AWS", "Kubernetes", "Docker", "ArgoCD", "Terraform", "Nginx"],
   Database: ["PostgreSQL", "Redis", "DynamoDB", "Apache Druid"],
-  "AI / LLM": ["OpenAI", "Gemini", "AWS Bedrock"],
+  "AI Engineering": ["Spring AI", "Function Calling", "OpenAI", "Gemini", "AWS Bedrock"],
+  "AI-native Workflow": ["Claude Code", "Codex", "MCP", "AI-assisted Code Review"],
   Monitoring: ["Grafana", "Loki", "Tempo", "Mimir", "OpenTelemetry", "Prometheus"],
   Tools: ["Git", "GitHub Actions", "JMeter", "Notion"],
 }
@@ -190,10 +212,13 @@ export const PROJECTS: ProjectDetail[] = [
     company: "주식회사 데이원컴퍼니",
     name: "결제 시스템 전면 재설계",
     period: "2025.03 — 2025.09",
-    tech: ["Java", "Spring Boot", "Redis", "Portone"],
+    tech: ["Java", "Spring Boot", "Redis", "Portone", "Claude Code", "MCP"],
     tasks: [
       {
         content: "PHP 레거시 결제 시스템을 Java/Spring으로 이관하고, PortOne v1에서 v2로 점진 전환하면서 하위 호환성 유지",
+      },
+      {
+        content: "**PortOne MCP를 Claude Code에 연결**해 V2 API·SDK 명세를 개발 컨텍스트에서 직접 확인하고 `PortoneV2Service` 구현에 활용",
       },
       {
         content: "결제 승인·검증·후처리 단계를 명확히 분리하고 API 기반 처리 흐름으로 재설계해 결제 상태 추적과 트랜잭션 경계를 단순화",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -169,6 +169,7 @@ export interface Translations {
   about: {
     description: string
     introduction: string
+    aiNativeDevelopment: string
     skills: string
     experience: string
     projects: string
@@ -378,8 +379,9 @@ export const ko: Translations = {
     noSeriesData: "시리즈 데이터 없음",
   },
   about: {
-    description: "비즈니스 흐름을 제품 기능으로 만들고, 안정적으로 확장되는 서비스 구조까지 설계하는 백엔드 엔지니어입니다.",
+    description: "생성형 AI를 개발 전 과정에 활용하며, BE/FE와 인프라를 연결해 제품을 완성하는 소프트웨어 엔지니어입니다.",
     introduction: "자기소개",
+    aiNativeDevelopment: "AI-native 개발 방식",
     skills: "기술 스택",
     experience: "경력",
     projects: "프로젝트",
@@ -589,8 +591,9 @@ export const en: Translations = {
     noSeriesData: "No series data",
   },
   about: {
-    description: "Backend engineer who turns business flows into product features and designs service structures that scale reliably.",
+    description: "Software engineer who uses generative AI throughout development to deliver products across backend, frontend, and infrastructure.",
     introduction: "About Me",
+    aiNativeDevelopment: "AI-native Development",
     skills: "Skills",
     experience: "Experience",
     projects: "Projects",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -271,6 +271,23 @@ export function AboutPage() {
 
       <Separator />
 
+      {/* AI-native Development */}
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">{t.about.aiNativeDevelopment}</h2>
+        <div className="grid gap-3 md:grid-cols-3">
+          {resume.aiNativeWorkflow.map((item) => (
+            <div key={item.title} className="rounded-lg border bg-card p-4">
+              <h3 className="font-semibold">{item.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {renderBold(item.description)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <Separator />
+
       {/* Experience + Projects */}
       <section>
         <h2 className="text-2xl font-semibold mb-4">{t.about.experience}</h2>


### PR DESCRIPTION
## 변경 내용

- 이력서 헤드라인과 자기소개를 AI-native 제품 개발 관점으로 개편했습니다.
- 요구사항 분석부터 BE/FE 구현, 테스트, 리뷰, 문서화까지의 AI 활용 방식을 별도 섹션으로 추가했습니다.
- Frontend, AI Engineering, AI-native Workflow 기술 스택을 보강했습니다.
- PortOne MCP와 Claude Code 활용 경험을 결제 프로젝트에 구체적으로 연결했습니다.
- 한국어·영문 웹 이력서와 PDF 출력 내용을 함께 동기화했습니다.

## 변경 이유

백엔드 중심의 기존 소개만으로는 생성형 AI를 개발 전 과정에 활용하고 프론트엔드·인프라까지 연결해 제품을 완성하는 업무 방식을 충분히 전달하기 어려웠습니다.

## 검증

- `pnpm lint` (오류 0개, 기존 경고 16개)
- `pnpm build`
- `pnpm check:internal-links`
- `pnpm test:post-dates`
- `pnpm test:sitemap-lastmod`
- 데스크톱·모바일 웹 레이아웃 및 6페이지 PDF 렌더링 확인
