### PR TITLE
fix(i18n): 언어 전환 안내 양방향 지원

### DIFF
--- a/src/components/LanguageSuggestionBanner.tsx
+++ b/src/components/LanguageSuggestionBanner.tsx
@@ -2,57 +2,63 @@ import { useEffect, useState } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
 import { Languages } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { en } from "@/i18n/translations"
+import { en, ko, type Language } from "@/i18n/translations"
 import { analytics } from "@/lib/analytics"
 import {
+  detectSupportedBrowserLanguage,
   getRouteLanguage,
   getStoredLanguage,
   localizePath,
-  prefersEnglishBrowser,
   setStoredLanguage,
   stripLanguagePrefix,
 } from "@/lib/i18n-routing"
 
-const SESSION_DISMISS_KEY = "language-suggestion-dismissed"
+const koreanPostFiles = import.meta.glob("/content/posts/ko/*.md", {
+  query: "?raw",
+  import: "default",
+})
 const englishPostFiles = import.meta.glob("/content/posts/en/*.md", {
   query: "?raw",
   import: "default",
 })
+const localizedPostFiles = { ko: koreanPostFiles, en: englishPostFiles } satisfies Record<Language, Record<string, () => Promise<unknown>>>
 const localizedStaticPaths = new Set(["/", "/posts", "/tags", "/series", "/analytics", "/about", "/privacy"])
 
-function isSessionDismissed() {
+function sessionDismissKey(source: Language, target: Language) {
+  return `language-suggestion-dismissed:${source}-${target}`
+}
+
+function isSessionDismissed(source: Language, target: Language) {
   try {
-    return window.sessionStorage.getItem(SESSION_DISMISS_KEY) === "true"
+    return window.sessionStorage.getItem(sessionDismissKey(source, target)) === "true"
   } catch {
     return false
   }
 }
 
-function dismissForSession() {
+function dismissForSession(source: Language, target: Language) {
   try {
-    window.sessionStorage.setItem(SESSION_DISMISS_KEY, "true")
+    window.sessionStorage.setItem(sessionDismissKey(source, target), "true")
   } catch {
     // Restricted browser storage should not prevent dismissing the current render.
   }
 }
 
-async function hasEnglishAlternative(pathname: string) {
-  if (getRouteLanguage(pathname) === "en") return false
-
+async function hasLanguageAlternative(pathname: string, targetLanguage: Language) {
   const normalizedPath = stripLanguagePrefix(pathname).replace(/\/+$/, "") || "/"
   if (localizedStaticPaths.has(normalizedPath)) return true
 
   const projectSlug = normalizedPath.match(/^\/about\/projects\/([^/]+)$/)?.[1]
   if (projectSlug) {
     const { getResumeData } = await import("@/data/resume-i18n")
-    return getResumeData("en").projects.some((project) => project.slug === decodeURIComponent(projectSlug))
+    return getResumeData(targetLanguage).projects.some((project) => project.slug === decodeURIComponent(projectSlug))
   }
 
   const postSlug = normalizedPath.match(/^\/posts\/([^/]+)$/)?.[1]
   if (!postSlug) return false
 
   try {
-    return Boolean(englishPostFiles[`/content/posts/en/${decodeURIComponent(postSlug)}.md`])
+    return Boolean(localizedPostFiles[targetLanguage][`/content/posts/${targetLanguage}/${decodeURIComponent(postSlug)}.md`])
   } catch {
     return false
   }
@@ -61,22 +67,27 @@ async function hasEnglishAlternative(pathname: string) {
 export function LanguageSuggestionBanner() {
   const location = useLocation()
   const navigate = useNavigate()
-  const [visible, setVisible] = useState(false)
-  const copy = en.components
+  const [targetLanguage, setTargetLanguage] = useState<Language | null>(null)
 
   useEffect(() => {
     let active = true
 
     async function updateVisibility() {
-      if (isSessionDismissed()) {
-        if (active) setVisible(false)
+      const sourceLanguage = getRouteLanguage(location.pathname)
+      const preferredLanguage = getStoredLanguage() ?? detectSupportedBrowserLanguage()
+
+      if (!preferredLanguage || preferredLanguage === sourceLanguage) {
+        if (active) setTargetLanguage(null)
         return
       }
 
-      const storedLanguage = getStoredLanguage()
-      const prefersEnglish = storedLanguage ? storedLanguage === "en" : prefersEnglishBrowser()
-      const hasAlternative = prefersEnglish && await hasEnglishAlternative(location.pathname)
-      if (active) setVisible(hasAlternative)
+      if (isSessionDismissed(sourceLanguage, preferredLanguage)) {
+        if (active) setTargetLanguage(null)
+        return
+      }
+
+      const hasAlternative = await hasLanguageAlternative(location.pathname, preferredLanguage)
+      if (active) setTargetLanguage(hasAlternative ? preferredLanguage : null)
     }
 
     void updateVisibility()
@@ -85,21 +96,25 @@ export function LanguageSuggestionBanner() {
     }
   }, [location.pathname])
 
-  if (!visible) return null
+  if (!targetLanguage) return null
 
-  function viewInEnglish() {
-    setStoredLanguage("en")
-    analytics.changeLanguage("en")
-    setVisible(false)
+  const sourceLanguage = getRouteLanguage(location.pathname)
+  const target = targetLanguage
+  const copy = (target === "en" ? en : ko).components
+
+  function viewInPreferredLanguage() {
+    setStoredLanguage(target)
+    analytics.changeLanguage(target)
+    setTargetLanguage(null)
     navigate(
-      localizePath(`${location.pathname}${location.search}${location.hash}`, "en"),
+      localizePath(`${location.pathname}${location.search}${location.hash}`, target),
       { viewTransition: true },
     )
   }
 
   function dismiss() {
-    dismissForSession()
-    setVisible(false)
+    dismissForSession(sourceLanguage, target)
+    setTargetLanguage(null)
   }
 
   return (
@@ -117,8 +132,8 @@ export function LanguageSuggestionBanner() {
           </div>
         </div>
         <div className="flex shrink-0 gap-2">
-          <Button type="button" size="sm" className="flex-1 sm:flex-none" onClick={viewInEnglish}>
-            {copy.viewInEnglish}
+          <Button type="button" size="sm" className="flex-1 sm:flex-none" onClick={viewInPreferredLanguage}>
+            {copy.viewInLanguage}
           </Button>
           <Button type="button" size="sm" variant="outline" className="flex-1 bg-background sm:flex-none" onClick={dismiss}>
             {copy.notNow}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -206,7 +206,7 @@ export interface Translations {
     shortcutHelp: string
     languageSuggestionTitle: string
     languageSuggestionDescription: string
-    viewInEnglish: string
+    viewInLanguage: string
     notNow: string
     general: string
   }
@@ -421,9 +421,9 @@ export const ko: Translations = {
     shortcutSearch: "검색 열기",
     shortcutHelp: "단축키 안내 열기",
     shortcutSidebar: "사이드바 토글",
-    languageSuggestionTitle: "영문 페이지도 제공됩니다.",
-    languageSuggestionDescription: "현재 페이지를 유지하면서 영어로 전환할 수 있습니다.",
-    viewInEnglish: "영어로 보기",
+    languageSuggestionTitle: "이 페이지는 한국어로도 제공됩니다.",
+    languageSuggestionDescription: "현재 페이지를 유지하면서 한국어로 전환할 수 있습니다.",
+    viewInLanguage: "한국어로 보기",
     notNow: "나중에",
     general: "일반",
   },
@@ -640,7 +640,7 @@ export const en: Translations = {
     shortcutSidebar: "Toggle sidebar",
     languageSuggestionTitle: "This page is available in English.",
     languageSuggestionDescription: "Switch without losing your current page.",
-    viewInEnglish: "View in English",
+    viewInLanguage: "View in English",
     notNow: "Not now",
     general: "General",
   },

--- a/src/lib/i18n-routing.ts
+++ b/src/lib/i18n-routing.ts
@@ -25,22 +25,15 @@ export function setStoredLanguage(language: Language) {
   }
 }
 
-export function detectBrowserLanguage(): Language {
-  if (typeof navigator === "undefined") return "ko"
+export function detectSupportedBrowserLanguage(): Language | null {
+  if (typeof navigator === "undefined") return null
 
   const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
   const primaryLanguage = languages.find((language) => language.trim().length > 0)?.toLowerCase()
 
-  return primaryLanguage?.startsWith("ko") ? "ko" : "en"
-}
-
-export function prefersEnglishBrowser(): boolean {
-  if (typeof navigator === "undefined") return false
-
-  const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
-  const primaryLanguage = languages.find((language) => language.trim().length > 0)?.toLowerCase()
-
-  return primaryLanguage?.startsWith("en") ?? false
+  if (primaryLanguage?.startsWith("ko")) return "ko"
+  if (primaryLanguage?.startsWith("en")) return "en"
+  return null
 }
 
 export function getRouteLanguage(pathname: string): Language {


### PR DESCRIPTION
## 목적

영어 브라우저의 한국어 페이지뿐 아니라 한국어 브라우저의 영문 페이지에서도 대응 언어로 안전하게 전환할 수 있도록 언어 제안 배너를 양방향으로 확장합니다.

## 내용(의도 포함)

- 현재 URL 언어와 저장된 선호 언어 또는 브라우저 언어를 비교해 `ko→en`, `en→ko` 양쪽 배너를 표시합니다.
- 한국어 대상 배너 문구와 `한국어로 보기` 동작을 추가했습니다.
- 명시적으로 저장된 언어를 브라우저 언어보다 우선하고, `ko`·`en` 이외 브라우저 언어에는 배너를 표시하지 않습니다.
- 글과 프로젝트의 대상 언어 버전이 실제로 존재할 때만 배너를 표시합니다.
- `Not now` 상태를 `ko-en`, `en-ko` 방향별 sessionStorage 키로 분리했습니다.
- 사용자가 버튼을 누르기 전에는 현재 URL과 canonical을 변경하지 않습니다.

## 성공기준

- `pnpm build` 통과
- `pnpm type-check` 통과
- `pnpm check:internal-links` 통과
- `pnpm test:post-dates` 6개 통과
- `pnpm test:sitemap-lastmod` 6개 통과
- 변경 파일 ESLint 오류·경고 없음
- 한국어 브라우저에서 `/en/about/` 접근 시 한국어 배너와 self-canonical 유지
- `한국어로 보기` 선택 시 `/about/`, `lang=ko`, 한국어 self-canonical 전환
- `en→ko`의 `나중에` 선택이 `ko→en` 배너를 숨기지 않음
- 390px 모바일에서 가로 넘침 및 브라우저 오류 없음
